### PR TITLE
fix/hydran 750 deduplicate engagements shown

### DIFF
--- a/backend/src/services/business-engagements.service.ts
+++ b/backend/src/services/business-engagements.service.ts
@@ -9,6 +9,24 @@ import { Mandates } from '@/data-contracts/myrepresentatives/data-contracts';
 import { logger } from '@/utils/logger';
 import { HttpError } from 'routing-controllers';
 
+const prioritizeEngagements = (engagements: PersonEngagement[]): PersonEngagement[] => {
+  // Filter out engagements without organization number
+  const validEngagements = engagements.filter(engagement => engagement.organizationNumber);
+
+  if (validEngagements.length === 0) return [];
+
+  // Prioritize Bolagsverket engagements, then add unique engagements from other sources
+  const bolagsverketEngagements = validEngagements.filter(engagement => engagement.source === 'Bolagsverket');
+  const bolagsverketOrgNumbers = new Set(bolagsverketEngagements.map(e => e.organizationNumber));
+  const uniqueOtherEngagements = validEngagements.filter(
+    engagement => engagement.source !== 'Bolagsverket' && !bolagsverketOrgNumbers.has(engagement.organizationNumber),
+  );
+
+  return [...bolagsverketEngagements, ...uniqueOtherEngagements].sort((a, b) =>
+    a.organizationNumber.localeCompare(b.organizationNumber),
+  );
+};
+
 export const getBusinessEngagements = async (user: User): Promise<PersonEngagement[]> => {
   if (!user.personNumber) {
     throw new Error('Bad Request: personalNumber is required');
@@ -47,9 +65,16 @@ export const getBusinessEngagements = async (user: User): Promise<PersonEngageme
     }
   }
 
-  await addEngagementFromMandate(user, apiService, apiBase, res);
+  // Add engagements from mandates and just pass if error occurs
+  try {
+    await addEngagementFromMandate(user, apiService, apiBase, res);
+  } catch (error) {
+    logger.error('Could not add engagements from mandate', error);
+  }
 
-  return res.data ?? [];
+  if (!res.data) return [];
+
+  return prioritizeEngagements(res.data);
 };
 
 export const getBusinessInformation = async (


### PR DESCRIPTION
# Pull Request

## Description

Fixed duplicate entries for organizations with registered names. The same organization appeared twice - once as "Enskild näringsverksamhet" and once with its registered name. Added deduplication logic that prioritizes Bolagsverket data and filters by organization number.

## Background & Motivation

Organizations with registered names appeared twice in the business list because data from multiple sources (Bolagsverket, SCB) returned the same organization number with different names. This created confusion for users. The fix prioritizes Bolagsverket as the authoritative source and removes duplicates based on organization number.

https://jira.sundsvall.se/browse/HYDRAN-750

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
