### PR TITLE
fix: hide medgivande in production

### DIFF
--- a/frontend/cypress/e2e/sidoverskridande.cy.ts
+++ b/frontend/cypress/e2e/sidoverskridande.cy.ts
@@ -46,7 +46,8 @@ describe('Sidöverskridande', () => {
 
     cy.get('[data-cy="user-menu"]').should('exist').contains('Förnamn Efternamn').click();
     cy.get('[data-cy="user-menu-profile-button"]').should('exist').should('have.text', 'Profil och inställningar');
-    cy.get('[data-cy="user-menu-eligibility-button"]').should('exist').should('have.text', 'Medgivanden');
+    // NOTE: Hide until release
+    // cy.get('[data-cy="user-menu-eligibility-button"]').should('exist').should('have.text', 'Medgivanden');
     cy.get('[data-cy="user-menu-logout-button"]').should('exist').should('have.text', 'Logga ut');
     cy.get('[data-cy="desktop-navigation"] li').should('have.length', 5);
   });

--- a/frontend/src/layouts/banner-menu/banner-menu-items.tsx
+++ b/frontend/src/layouts/banner-menu/banner-menu-items.tsx
@@ -58,13 +58,18 @@ export const useBannerMenuItems = () => {
     >
       {capitalize(t('common:profile'))}
     </NextLink>,
-    <NextLink
-      key={`banner-menu-item-5`}
-      className="w-full flex items-center justify-center"
-      href={`${myPagesRoute}/medgivanden`}
-    >
-      {capitalize(t('common:eligibility'))}
-    </NextLink>,
+    <>
+      {/* NOTE: Don't show in production */}
+      {process.env.NODE_ENV !== 'production' && (
+        <NextLink
+          key={`banner-menu-item-5`}
+          className="w-full flex items-center justify-center"
+          href={`${myPagesRoute}/medgivanden`}
+        >
+          {capitalize(t('common:eligibility'))}
+        </NextLink>
+      )}
+    </>,
   ];
 
   return isMinDesktop ? bannerItems : mobileMenuItems;

--- a/frontend/src/layouts/user-menu/user-menu.component.tsx
+++ b/frontend/src/layouts/user-menu/user-menu.component.tsx
@@ -50,18 +50,21 @@ export const UserMenu = () => {
                   <Icon icon={<ArrowRight />} />
                 </Button>
               </PopupMenu.Item>
-              <PopupMenu.Item>
-                <Button
-                  className="!justify-between"
-                  onClick={() => {
-                    router.push('medgivanden');
-                  }}
-                  data-cy="user-menu-eligibility-button"
-                >
-                  {capitalize(t('common:eligibility'))}
-                  <Icon icon={<ArrowRight />} />
-                </Button>
-              </PopupMenu.Item>
+              {/* NOTE: Don't show in production */}
+              {process.env.NODE_ENV !== 'production' && (
+                <PopupMenu.Item>
+                  <Button
+                    className="!justify-between"
+                    onClick={() => {
+                      router.push('medgivanden');
+                    }}
+                    data-cy="user-menu-eligibility-button"
+                  >
+                    {capitalize(t('common:eligibility'))}
+                    <Icon icon={<ArrowRight />} />
+                  </Button>
+                </PopupMenu.Item>
+              )}
               <Divider />
               <PopupMenu.Item>
                 <Button


### PR DESCRIPTION
# Pull Request

## Description

Medgivande är inte klart för produktionssättning. Vi döljer därför menyn i prod.

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
