### PR TITLE
Feat/hydran 1253 update api service bfus

### DIFF
--- a/backend/src/controllers/bfus.controller.ts
+++ b/backend/src/controllers/bfus.controller.ts
@@ -24,7 +24,7 @@ import { User } from '@/interfaces/users.interface';
 
 @Controller('/bfus')
 export class BFUSController {
-  private apiService = new ApiService();
+  private readonly apiService = new ApiService();
   private apiBase = getApiBase('bfus');
 
   async processPermission(operation: PermissionHeaderDto['Operation'], request: PermissionRequestDto, user: User) {

--- a/backend/src/controllers/bfus.controller.ts
+++ b/backend/src/controllers/bfus.controller.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL, BFUS_API_KEY, BFUS_EXTERNAL_ID } from '@/config';
+import { BFUS_EXTERNAL_ID } from '@/config';
 import { HttpException } from '@/exceptions/HttpException';
 import { RequestWithUser } from '@/interfaces/auth.interface';
 import {
@@ -9,34 +9,25 @@ import {
 import authMiddleware from '@/middlewares/auth.middleware';
 import { BFUSApiResponse, BFUSEligablePartyApiResponse, BFUSNewPermissionApiResponse } from '@/responses/bfus.response';
 import { logger } from '@/utils/logger';
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 import { Response } from 'express';
 import { Body, Controller, Get, HttpCode, HttpError, Post, QueryParam, Req, Res, UseBefore } from 'routing-controllers';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 import { UpdatePermissionDto } from '@/dtos/update-permission.dto';
-import { sendPermissionRequest } from '@/services/bfus.service';
+import { handleCustomerIds, sendPermissionRequest } from '@/services/bfus.service';
 import { FullPermissionDto, PermissionRequestDto } from '@/dtos/permission-request.dto';
 import { PermissionHeaderDto } from '@/dtos/permission-header.dto';
 import { mapPartStatus } from '@/utils/bfus-permission-status-code-helpers';
-import ApiTokenService from '@/services/api-token.service';
 import { getApiBase } from '@/config/api-config';
+import ApiService from '@/services/api.service';
+import { User } from '@/interfaces/users.interface';
 
 @Controller('/bfus')
 export class BFUSController {
+  private apiService = new ApiService();
   private apiBase = getApiBase('bfus');
 
-  async requireToken(): Promise<string> {
-    const apiTokenService = new ApiTokenService();
-    const token = await apiTokenService.getToken();
-
-    if (!token) {
-      throw new HttpException(500, 'No token');
-    }
-
-    return token;
-  }
-
-  async processPermission(operation: PermissionHeaderDto['Operation'], request: PermissionRequestDto) {
+  async processPermission(operation: PermissionHeaderDto['Operation'], request: PermissionRequestDto, user: User) {
     const now = new Date().toLocaleDateString();
     const body: FullPermissionDto = {
       Header: {
@@ -58,7 +49,7 @@ export class BFUSController {
     }
 
     try {
-      const result = await sendPermissionRequest(body, () => this.requireToken());
+      const result = await sendPermissionRequest(body, user, this.apiBase);
       return result;
     } catch (error) {
       logger.error(`Error processing permission (${operation})`, error);
@@ -87,21 +78,16 @@ export class BFUSController {
     }
 
     try {
-      const token = await this.requireToken();
       const results = await Promise.allSettled(
         relations.customerNumber.map(cn => {
-          const url = `${API_BASE_URL}/${this.apiBase}/EP/Customer/GetEPCustomerByCode_v1/${BFUS_EXTERNAL_ID}/${cn}`;
-          return axios.get<BFUSCustomerResponse>(url, {
-            headers: { Authorization: `Bearer ${token}, ${BFUS_API_KEY}` },
-          });
+          const url = `${this.apiBase}/EP/Customer/GetEPCustomerByCode_v1/${BFUS_EXTERNAL_ID}/${cn}`;
+          return this.apiService.get<BFUSCustomerResponse>({ url }, req.user);
         }),
       );
 
       const customerIds = results
         .filter(r => r.status === 'fulfilled')
-        .map(
-          (r: PromiseFulfilledResult<AxiosResponse<BFUSCustomerResponse>>) => r.value.data.Content.Customer.CustomerId,
-        );
+        .map(r => r.value.data.Content.Customer.CustomerId);
 
       return res.send({
         data: {
@@ -119,42 +105,30 @@ export class BFUSController {
   @OpenAPI({ summary: 'Check if user has new permissions' })
   @UseBefore(authMiddleware)
   async hasNewPermissions(
+    @Req() req: RequestWithUser,
     @Res() res: Response<BFUSNewPermissionApiResponse>,
     @QueryParam('customerIds') customerIds: string,
   ): Promise<Response<BFUSNewPermissionApiResponse>> {
-    if (!customerIds) {
-      throw new HttpException(400, 'No customer ids found');
-    }
-
-    const ids = customerIds
-      .split(',')
-      .map(id => Number(id.trim()))
-      .filter(id => !Number.isNaN(id));
-
-    if (!ids.length) {
-      throw new HttpException(400, 'Customer ids must be numbers');
-    }
+    const ids = await handleCustomerIds(customerIds);
 
     try {
-      const token = await this.requireToken();
       const responses = await Promise.allSettled(
         ids.map(cn => {
-          const url = `${API_BASE_URL}/${this.apiBase}/EP/EligableParty/NewPermissions/${BFUS_EXTERNAL_ID}/${cn}`;
-          return axios.get<BFUSHasNewPermissionResponse>(url, {
-            headers: { Authorization: `Bearer ${token}, ${BFUS_API_KEY}` },
-          });
+          const url = `${this.apiBase}/EP/EligableParty/NewPermissions/${BFUS_EXTERNAL_ID}/${cn}`;
+          return this.apiService.get<BFUSHasNewPermissionResponse>({ url }, req.user);
         }),
       );
 
+      const newPermissions = responses
+        .filter(r => r.status === 'fulfilled')
+        .map(r => r.value.data.Content.NewPermissions);
+
       return res.send({
-        data: responses.some(
-          (r: PromiseFulfilledResult<AxiosResponse<BFUSHasNewPermissionResponse>>) =>
-            r.value.data.Content.NewPermissions.HasPermissions === true,
-        ),
+        data: newPermissions.some(r => r.HasPermissions === true),
         message: 'success',
       });
     } catch (error: any) {
-      logger.error('Unexpected error in BFUS Customer', error.message);
+      logger.error('Unexpected error in eligable party new permissions', error.message);
       throw new HttpError(500, 'Unexpected server error');
     }
   }
@@ -164,65 +138,56 @@ export class BFUSController {
   @ResponseSchema(BFUSEligablePartyApiResponse)
   @UseBefore(authMiddleware)
   async GetEligablePartyPermissions(
+    @Req() req: RequestWithUser,
     @QueryParam('customerIds') customerIds: string,
     @Res() res: Response<BFUSEligablePartyApiResponse>,
   ): Promise<Response<BFUSEligablePartyApiResponse>> {
-    if (!customerIds) {
-      throw new HttpException(400, 'No customer ids found');
-    }
-
-    const ids = customerIds
-      .split(',')
-      .map(id => Number(id.trim()))
-      .filter(id => !Number.isNaN(id));
-
-    if (!ids.length) {
-      throw new HttpException(400, 'Customer ids must be numbers');
-    }
+    const ids = await handleCustomerIds(customerIds);
 
     try {
-      const token = await this.requireToken();
-      const responses = await Promise.all(
+      const responses = await Promise.allSettled(
         ids.map(customerId => {
-          const url = `${API_BASE_URL}/${this.apiBase}/EP/EligableParty/EligablePartyPermissions/${BFUS_EXTERNAL_ID}/${customerId}`;
-          return axios.get<BFUSEligablePartyResponse>(url, {
-            headers: { Authorization: `Bearer ${token}, ${BFUS_API_KEY}` },
-          });
+          const url = `${this.apiBase}/EP/EligableParty/EligablePartyPermissions/${BFUS_EXTERNAL_ID}/${customerId}`;
+          return this.apiService.get<BFUSEligablePartyResponse>({ url }, req.user);
         }),
       );
 
-      const eligablePartyParts = responses.flatMap(r => r.data.Content?.EligablePartyParts ?? []);
+      const permissions = responses
+        .filter(r => r.status === 'fulfilled')
+        .map(r => r.value.data.Content.EligablePartyParts);
 
-      const mappedParts = eligablePartyParts.map(p => ({
+      const permissionParts = permissions.flatMap(r => r ?? []);
+
+      const mappedParts = permissionParts.map(p => ({
         ...p,
         StatusCategory: mapPartStatus(p),
       }));
 
       return res.send({
-        message: mappedParts.length ? 'success' : 'no eligable party parts available',
+        message: mappedParts.length ? 'success' : 'no eligable party permission parts available',
         data: { eligablePartyParts: mappedParts },
       });
     } catch (error: any) {
-      logger.error('Unexpected error in BFUS aggregated eligable party permissions', error.message);
+      logger.error('Unexpected error in eligable party permissions', error.message);
       throw new HttpError(500, 'Unexpected server error');
     }
   }
 
   @Post('/eligable-party-grant-permission')
   @HttpCode(201)
-  async grantPermission(@Body() dto: UpdatePermissionDto) {
-    return this.processPermission('grant', dto.PermissionRequest);
+  async grantPermission(@Req() req: RequestWithUser, @Body() dto: UpdatePermissionDto) {
+    return this.processPermission('grant', dto.PermissionRequest, req.user);
   }
 
   @Post('/eligable-party-deny-permission')
   @HttpCode(200)
-  async denyPermission(@Body() dto: UpdatePermissionDto) {
-    return this.processPermission('deny', dto.PermissionRequest);
+  async denyPermission(@Req() req: RequestWithUser, @Body() dto: UpdatePermissionDto) {
+    return this.processPermission('deny', dto.PermissionRequest, req.user);
   }
 
   @Post('/eligable-party-revoke-permission')
   @HttpCode(200)
-  async revokePermission(@Body() dto: UpdatePermissionDto) {
-    return this.processPermission('revoke', dto.PermissionRequest);
+  async revokePermission(@Req() req: RequestWithUser, @Body() dto: UpdatePermissionDto) {
+    return this.processPermission('revoke', dto.PermissionRequest, req.user);
   }
 }

--- a/backend/src/services/bfus.service.ts
+++ b/backend/src/services/bfus.service.ts
@@ -1,17 +1,30 @@
-import { API_BASE_URL, BFUS_API_KEY } from '@/config';
 import { UpdatePermissionDto } from '@/dtos/update-permission.dto';
 import { BFUSEligablePartyPermissionResponse } from '@/interfaces/bfus.interface';
-import axios from 'axios';
-import { getApiBase } from '@/config/api-config';
+import { HttpException } from '@/exceptions/HttpException';
+import ApiService from './api.service';
+import { User } from '@/interfaces/users.interface';
 
-export const sendPermissionRequest = async (dto: UpdatePermissionDto, requireToken: () => Promise<string>) => {
-  const token = await requireToken();
-  const apiBase = getApiBase('bfus');
-  const url = `${API_BASE_URL}/${apiBase}/EP/EligableParty/PermissionRequest`;
-
-  const response = await axios.post<BFUSEligablePartyPermissionResponse>(url, dto, {
-    headers: { Authorization: `Bearer ${token}, ${BFUS_API_KEY}` },
-  });
+export const sendPermissionRequest = async (data: UpdatePermissionDto, user: User, apiBase: string) => {
+  const apiService = new ApiService();
+  const url = `${apiBase}/EP/EligableParty/PermissionRequest`;
+  const response = await apiService.post<BFUSEligablePartyPermissionResponse, UpdatePermissionDto>({ url, data }, user);
 
   return response.data;
+};
+
+export const handleCustomerIds = async (customerIds: string) => {
+  if (!customerIds) {
+    throw new HttpException(400, 'No customer ids found');
+  }
+
+  const ids = customerIds
+    .split(',')
+    .map(id => Number(id.trim()))
+    .filter(id => !Number.isNaN(id));
+
+  if (!ids.length) {
+    throw new HttpException(400, 'Customer ids must be numbers');
+  }
+
+  return ids;
 };

--- a/frontend/cypress/e2e/medgivanden.cy.ts
+++ b/frontend/cypress/e2e/medgivanden.cy.ts
@@ -25,7 +25,6 @@ describe('Dina medgivanden', () => {
   });
 
   it('should render a table for new and current and closed eligibility permissions', () => {
-    cy.get('[data-cy="current-and-closed-permissions-loader"]').should('exist');
     cy.wait('@getPartyPermissions', { timeout: 10000 }).its('response.statusCode').should('eq', 200);
     cy.get('[data-cy="current-and-closed-permissions-loader"]').should('not.exist');
     cy.get('[data-cy="current-and-closed-permissions"]').find('table').should('exist');

--- a/frontend/locales/sv/eligibility.json
+++ b/frontend/locales/sv/eligibility.json
@@ -2,6 +2,7 @@
   "title": "Dina medgivanden",
   "description": "Här kan du se och hantera vilka energitjänsteleverantörer som får ta del av dina mätvärden.",
   "noData": "Du har inga medgivanden.",
+  "noCustomerId": "Kunde inte hitta något kund-id. Försök igen.",
   "permissions": {
     "new": "Nytt medgivande",
     "current": "Aktuella",
@@ -17,7 +18,7 @@
       "address": "Adress",
       "facilityId": "Anläggnings-ID",
       "validTime": "Giltighetstid",
-      "approveAll" : "Godkänn medgivandet",
+      "approveAll": "Godkänn medgivandet",
       "approve": "Godkänn",
       "deny": "Neka medgivandet",
       "approveSuccess": "Medgivande godkändes",

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -7,7 +7,6 @@ import { CurrentAndClosedPermissionCard } from './current-and-closed-permissions
 import { queryClient, useApi } from '@services/api-service';
 import { EligablePartyPart, FullPermissionDto, PermissionRequestDto } from '@interfaces/eligibility';
 import { eligibilityQueryKeys, handleEligibilityResponse } from '@services/permissions-service';
-import { AxiosError } from 'axios';
 
 interface CurrentAndClosedEligibilityPermissionsProps {
   customerIds?: number[];

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -34,7 +34,7 @@ const CurrentAndClosedEligibilityPermissions = ({ customerIds }: CurrentAndClose
         customerIds: customerIds?.toString(),
       },
     },
-    dataHandler: handleEligibilityResponse(['ongoing', 'denied', 'revoked']),
+    dataHandler: handleEligibilityResponse(['ongoing', 'denied', 'revoked', 'expired']),
   });
 
   const revokeMutation = useApi<PermissionRequestDto, Error, FullPermissionDto>({

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -2,7 +2,7 @@ import { MouseEvent, useState } from 'react';
 import CurrentAndClosedEligibilityPermissionsTable from './current-and-closed-permissions-table/current-and-closed-eligibility-permissions-table';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
-import { Badge, Button, Label, Spinner, Tabs, useSnackbar, useThemeQueries } from '@sk-web-gui/react';
+import { Badge, Button, Label, Tabs, useSnackbar, useThemeQueries } from '@sk-web-gui/react';
 import { CurrentAndClosedPermissionCard } from './current-and-closed-permissions-card-item/current-and-closed-permissions-card-item';
 import { queryClient, useApi } from '@services/api-service';
 import {

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -28,7 +28,7 @@ const CurrentAndClosedEligibilityPermissions = ({ customerIds }: CurrentAndClose
     isFetching,
   } = useApi({
     url: '/bfus/eligable-party-permissions',
-    queryKey: ['current-and-closed-permissions'],
+    queryKey: [eligibilityQueryKeys.currentAndClosedPermissions],
     method: 'get',
     axiosParameters: {
       params: {
@@ -45,26 +45,27 @@ const CurrentAndClosedEligibilityPermissions = ({ customerIds }: CurrentAndClose
 
   const handleRevokePermission = (p: EligablePartyPart) => async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    await revokeMutation
-      .mutateAsync({
+    try {
+      await revokeMutation.mutateAsync({
         PermissionRequest: {
           EligablePartyId: p.EligablePartyId,
           ContractIdList: [p.ContractId],
         },
-      })
-      .then(() => {
-        snackBar({
-          message: t('eligibility:permissions.table.currentAndClosed.snackBarMessage.success'),
-          status: 'success',
-        });
-        queryClient.invalidateQueries({ queryKey: [eligibilityQueryKeys.partyPermissions] });
-      })
-      .catch((e: AxiosError) =>
-        snackBar({
-          message: `${t('eligibility:permissions.table.currentAndClosed.snackBarMessage.error')}: "${e.message}"`,
-          status: 'error',
-        })
-      );
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: [eligibilityQueryKeys.currentAndClosedPermissions],
+      });
+      snackBar({
+        message: t('eligibility:permissions.table.currentAndClosed.snackBarMessage.success'),
+        status: 'success',
+      });
+    } catch {
+      snackBar({
+        message: `${t('eligibility:permissions.table.currentAndClosed.snackBarMessage.error')}`,
+        status: 'error',
+      });
+    }
   };
 
   if (isLoading || isFetching || !permissions) {

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -58,11 +58,7 @@ const CurrentAndClosedEligibilityPermissions = ({ allPermissions }: CurrentAndCl
   };
 
   if (!permissions || Object.keys(permissions).length === 0) {
-    return (
-      <div className="w-full flex justify-center content-center p-24" data-cy="current-and-closed-permissions-loader">
-        <Spinner />
-      </div>
-    );
+    return null;
   }
 
   const currentAndClosedPermissions: EligablePartyPart[] = Object.values(permissions).flat();

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -5,14 +5,19 @@ import dayjs from 'dayjs';
 import { Badge, Button, Label, Spinner, Tabs, useSnackbar, useThemeQueries } from '@sk-web-gui/react';
 import { CurrentAndClosedPermissionCard } from './current-and-closed-permissions-card-item/current-and-closed-permissions-card-item';
 import { queryClient, useApi } from '@services/api-service';
-import { EligablePartyPart, FullPermissionDto, PermissionRequestDto } from '@interfaces/eligibility';
+import {
+  BFUSEligiblePartyPermissionsApiResponse,
+  EligablePartyPart,
+  FullPermissionDto,
+  PermissionRequestDto,
+} from '@interfaces/eligibility';
 import { eligibilityQueryKeys, handleEligibilityResponse } from '@services/permissions-service';
 
 interface CurrentAndClosedEligibilityPermissionsProps {
-  customerIds?: number[];
+  allPermissions: BFUSEligiblePartyPermissionsApiResponse['data'];
 }
 
-const CurrentAndClosedEligibilityPermissions = ({ customerIds }: CurrentAndClosedEligibilityPermissionsProps) => {
+const CurrentAndClosedEligibilityPermissions = ({ allPermissions }: CurrentAndClosedEligibilityPermissionsProps) => {
   const { t } = useTranslation('eligibility');
   const [activePanel, setActivePanel] = useState(0);
   const { isMinLg } = useThemeQueries();
@@ -20,22 +25,7 @@ const CurrentAndClosedEligibilityPermissions = ({ customerIds }: CurrentAndClose
   const formatDate = (date: string | null) =>
     date ? dayjs(date).format('YYYY-MM-DD') : t('eligibility:permissions.table.currentAndClosed.unknownDate');
   const snackBar = useSnackbar();
-
-  const {
-    data: permissions,
-    isLoading,
-    isFetching,
-  } = useApi({
-    url: '/bfus/eligable-party-permissions',
-    queryKey: [eligibilityQueryKeys.currentAndClosedPermissions],
-    method: 'get',
-    axiosParameters: {
-      params: {
-        customerIds: customerIds?.toString(),
-      },
-    },
-    dataHandler: handleEligibilityResponse(['ongoing', 'denied', 'revoked', 'expired']),
-  });
+  const permissions = handleEligibilityResponse(['ongoing', 'denied', 'revoked', 'expired'])(allPermissions);
 
   const revokeMutation = useApi<PermissionRequestDto, Error, FullPermissionDto>({
     url: 'bfus/eligable-party-revoke-permission',
@@ -67,7 +57,7 @@ const CurrentAndClosedEligibilityPermissions = ({ customerIds }: CurrentAndClose
     }
   };
 
-  if (isLoading || isFetching || !permissions) {
+  if (!permissions || Object.keys(permissions).length === 0) {
     return (
       <div className="w-full flex justify-center content-center p-24" data-cy="current-and-closed-permissions-loader">
         <Spinner />

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/eligibility.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/eligibility.component.tsx
@@ -5,30 +5,62 @@ import { useTranslation } from 'react-i18next';
 import { NewPermissions } from '@layouts/pages/mypages-sections/eligibility/new-permissions/new-permissions.component';
 import { Spinner } from '@sk-web-gui/react';
 import CurrentAndClosedEligibilityPermissions from './current-and-closed-permissions/current-and-closed-eligibility-permissions';
-import { useGetCustomerId } from '@services/permissions-service';
+import { eligibilityQueryKeys, useGetCustomerId } from '@services/permissions-service';
 import { useApi } from '@services/api-service';
 import { User } from '@interfaces/user';
+import { BFUSEligiblePartyPermissionsApiResponse } from '@interfaces/eligibility';
 
 export default function Eligibility() {
   const { t } = useTranslation('eligibility');
-  const { data: userData } = useApi<User>({ url: '/me', method: 'get', queryKey: ['user'] });
-  const { data: customerIds, isFetching } = useGetCustomerId(userData);
+
+  const { data: userData, isLoading: userLoading } = useApi<User>({
+    url: '/me',
+    method: 'get',
+    queryKey: ['user'],
+  });
+
+  const { data: customerIds, isLoading: customerLoading } = useGetCustomerId(userData);
+
+  const { data: allPermissions, isLoading: permissionsLoading } = useApi<
+    BFUSEligiblePartyPermissionsApiResponse['data']
+  >({
+    url: '/bfus/eligable-party-permissions',
+    queryKey: [eligibilityQueryKeys.partyPermissions],
+    method: 'get',
+    axiosParameters: {
+      params: {
+        customerIds: customerIds?.toString(),
+      },
+    },
+    queryOptions: {
+      enabled: !!customerIds?.length,
+    },
+  });
+
+  const isLoading = userLoading || customerLoading || permissionsLoading;
+  const hasCustomerIds = !!customerIds?.length;
+  const hasPermissions = !!allPermissions && allPermissions.eligablePartyParts.length > 0;
 
   return (
     <div>
       <h1>{t('eligibility:title')}</h1>
       <p>{t('eligibility:description')}</p>
 
-      {isFetching ? (
-        <Spinner />
-      ) : customerIds ? (
-        <div className="pt-40">
-          <NewPermissions customerIds={customerIds} />
-          <CurrentAndClosedEligibilityPermissions customerIds={customerIds} />
-        </div>
-      ) : (
-        <p className="pt-40">{t('eligibility.noData')}</p>
-      )}
+      <div className="pt-40">
+        {isLoading && (
+          <div className="w-full flex justify-center">
+            <Spinner />
+          </div>
+        )}
+        {!isLoading && !hasCustomerIds && <p>{t('eligibility:noCustomerId')}</p>}
+        {!isLoading && hasCustomerIds && !hasPermissions && <p>{t('eligibility:noData')}</p>}
+        {!isLoading && hasCustomerIds && hasPermissions && (
+          <>
+            <NewPermissions allPermissions={allPermissions} />
+            <CurrentAndClosedEligibilityPermissions allPermissions={allPermissions} />
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/new-permissions/new-permissions.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/new-permissions/new-permissions.component.tsx
@@ -7,10 +7,14 @@ import { NewPermissionListItem } from '@layouts/pages/mypages-sections/eligibili
 import React from 'react';
 import { useSnackbar, useThemeQueries } from '@sk-web-gui/react';
 import { NewPermissionCardItem } from '@layouts/pages/mypages-sections/eligibility/new-permissions/new-permission-card-item/new-permission-card-item.component';
-import { EligablePartyPart, PermissionRequestDto } from '@interfaces/eligibility';
+import {
+  BFUSEligiblePartyPermissionsApiResponse,
+  EligablePartyPart,
+  PermissionRequestDto,
+} from '@interfaces/eligibility';
 
 interface NewPermissionsProps {
-  customerIds: number[];
+  allPermissions: BFUSEligiblePartyPermissionsApiResponse['data'];
 }
 
 type PermissionMutationOptions<TPayload> = {
@@ -23,7 +27,7 @@ type PermissionMutationOptions<TPayload> = {
 };
 
 export const NewPermissions = (props: NewPermissionsProps) => {
-  const { customerIds } = props;
+  const { allPermissions } = props;
   const { t } = useTranslation(['common', 'eligibility']);
   const { isMinLg } = useThemeQueries();
 
@@ -38,17 +42,7 @@ export const NewPermissions = (props: NewPermissionsProps) => {
     method: 'post',
   });
 
-  const { data: newPermissions } = useApi({
-    url: '/bfus/eligable-party-permissions',
-    queryKey: [eligibilityQueryKeys.newPermissions],
-    method: 'get',
-    axiosParameters: {
-      params: {
-        customerIds: customerIds?.toString(),
-      },
-    },
-    dataHandler: handleEligibilityResponse('new'),
-  });
+  const newPermissions = handleEligibilityResponse('new')(allPermissions);
 
   const handlePermissionMutation = async ({
     payload,

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/new-permissions/new-permissions.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/new-permissions/new-permissions.component.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { queryClient, useApi } from '@services/api-service';
-import { handleEligibilityResponse } from '@services/permissions-service';
+import { eligibilityQueryKeys, handleEligibilityResponse } from '@services/permissions-service';
 import { NewPermissionListItem } from '@layouts/pages/mypages-sections/eligibility/new-permissions/new-permission-list-item/new-permission-list-item.component';
 import React from 'react';
 import { useSnackbar, useThemeQueries } from '@sk-web-gui/react';
@@ -40,7 +40,7 @@ export const NewPermissions = (props: NewPermissionsProps) => {
 
   const { data: newPermissions } = useApi({
     url: '/bfus/eligable-party-permissions',
-    queryKey: ['new-permissions'],
+    queryKey: [eligibilityQueryKeys.newPermissions],
     method: 'get',
     axiosParameters: {
       params: {
@@ -59,12 +59,14 @@ export const NewPermissions = (props: NewPermissionsProps) => {
     try {
       await mutation.mutateAsync(payload);
 
-      await queryClient.invalidateQueries({
-        queryKey: ['new-permissions'],
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ['bfus-eligible-party-permissions'],
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [eligibilityQueryKeys.newPermissions],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [eligibilityQueryKeys.currentAndClosedPermissions],
+        }),
+      ]);
       snackBar({
         message: successMessage,
         status: 'success',

--- a/frontend/src/layouts/pages/mypages-sections/overview/todo/todos.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/overview/todo/todos.component.tsx
@@ -6,15 +6,11 @@ import { useApi } from '@services/api-service';
 import { Spinner } from '@sk-web-gui/react';
 import { TodoListItem } from './todo-list-item.component';
 import { useTranslation } from 'react-i18next';
-import { BFUSCustomerIdsApiResponse } from '@interfaces/eligibility';
+import { useGetCustomerId } from '@services/permissions-service';
 
 export const Todos = () => {
   const { t } = useTranslation('overview');
-  const {
-    data: userData,
-    isFetching: userDataIsFetching,
-    isFetched: userIsFetched,
-  } = useApi<User>({
+  const { data: userData, isFetching: userDataIsFetching } = useApi<User>({
     url: '/me',
     method: 'get',
     queryKey: ['user'],
@@ -33,15 +29,7 @@ export const Todos = () => {
     method: 'get',
   });
 
-  const { data: customerIds, isFetched: customerIdsFetched } = useApi<BFUSCustomerIdsApiResponse['data']>({
-    url: '/bfus/eligable-party-customer-id',
-    queryKey: ['bfus-customer-ids'],
-    method: 'get',
-    queryOptions: {
-      enabled: userIsFetched,
-    },
-    dataHandler: (data) => data,
-  });
+  const { data: customerIds, isFetched: customerIdsFetched } = useGetCustomerId(userData);
 
   const { data: hasNewPermissions } = useApi({
     url: '/bfus/new-permissions',
@@ -49,11 +37,11 @@ export const Todos = () => {
     method: 'get',
     axiosParameters: {
       params: {
-        customerIds: customerIds?.customerIds.toString(),
+        customerIds: customerIds?.toString(),
       },
     },
     queryOptions: {
-      enabled: customerIdsFetched && customerIds && customerIds?.customerIds?.length > 0,
+      enabled: customerIdsFetched && customerIds && customerIds?.length > 0,
     },
   });
 

--- a/frontend/src/services/permissions-service.ts
+++ b/frontend/src/services/permissions-service.ts
@@ -10,6 +10,8 @@ import { User } from '@interfaces/user';
 
 export const eligibilityQueryKeys = {
   partyPermissions: 'bfus-eligible-party-permissions',
+  newPermissions: 'eligibility-new-permissions',
+  currentAndClosedPermissions: 'eligibility-current-and-closed-permissions',
   customerIds: 'bfus-customer-ids',
 };
 


### PR DESCRIPTION
# Pull Request

## Description

Uppdaterat controllers och services i BFF så att vi kan använda vår api service samt skippa att skicka med basic auth i headers.

Har även uppdaterat queries för att hämta om listor med medgivanden vid mutation (invalidate queries=

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1253

## General Checklist

- [x] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
