### PR TITLE
Feat/hydran 1419 revoke status label

### DIFF
--- a/frontend/locales/sv/eligibility.json
+++ b/frontend/locales/sv/eligibility.json
@@ -43,7 +43,8 @@
           "denied": "Nekad",
           "ended": "Löpt ut",
           "revoked": "Återkallad",
-          "ongoing": "Pågående"
+          "ongoing": "Pågående",
+          "revoking": "Återkallas"
         },
         "revokeAction": "Återkalla medgivande",
         "snackBarMessage": {

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -78,7 +78,7 @@ const CurrentAndClosedEligibilityPermissions = ({
 
   const revokeActionButton = (p: EligablePartyPart) =>
     activePanel === 0 ? (
-      p.UserRevokedContractTime ? (
+      p.UserRevokedContractTime && p.StatusCategory === 'ongoing' ? (
         <Label rounded inverted color="warning">
           {t(`eligibility:permissions.table.currentAndClosed.status.revoking`)}
         </Label>

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -78,9 +78,15 @@ const CurrentAndClosedEligibilityPermissions = ({
 
   const revokeActionButton = (p: EligablePartyPart) =>
     activePanel === 0 ? (
-      <Button variant="tertiary" size={isMinLg ? 'sm' : 'lg'} onClick={handleRevokePermission(p)} className="flex-1">
-        {t('eligibility:permissions.table.currentAndClosed.revokeAction')}
-      </Button>
+      p.UserRevokedContractTime ? (
+        <Label rounded inverted color="warning">
+          {t(`eligibility:permissions.table.currentAndClosed.status.revoking`)}
+        </Label>
+      ) : (
+        <Button variant="tertiary" size={isMinLg ? 'sm' : 'lg'} onClick={handleRevokePermission(p)} className="flex-1">
+          {t('eligibility:permissions.table.currentAndClosed.revokeAction')}
+        </Button>
+      )
     ) : (
       closedLabel(p.StatusCategory)
     );

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -77,6 +77,10 @@ const CurrentAndClosedEligibilityPermissions = ({
   };
 
   const revokeActionButton = (p: EligablePartyPart) => {
+    if (activePanel !== 0) {
+      return closedLabel(p.StatusCategory);
+    }
+
     if (p.UserRevokedContractTime && p.StatusCategory === 'ongoing') {
       return (
         <Label rounded inverted color="warning">
@@ -86,7 +90,13 @@ const CurrentAndClosedEligibilityPermissions = ({
     }
 
     return (
-      <Button variant="tertiary" size={isMinLg ? 'sm' : 'lg'} onClick={handleRevokePermission(p)} className="flex-1">
+      <Button
+        variant="tertiary"
+        size={isMinLg ? 'sm' : 'lg'}
+        onClick={handleRevokePermission(p)}
+        className="flex-1"
+        daya-cy="revoke-button"
+      >
         {t('eligibility:permissions.table.currentAndClosed.revokeAction')}
       </Button>
     );

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -95,7 +95,7 @@ const CurrentAndClosedEligibilityPermissions = ({
         size={isMinLg ? 'sm' : 'lg'}
         onClick={handleRevokePermission(p)}
         className="flex-1"
-        daya-cy="revoke-button"
+        data-cy="revoke-button"
       >
         {t('eligibility:permissions.table.currentAndClosed.revokeAction')}
       </Button>

--- a/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/eligibility/current-and-closed-permissions/current-and-closed-eligibility-permissions.tsx
@@ -76,20 +76,21 @@ const CurrentAndClosedEligibilityPermissions = ({
     );
   };
 
-  const revokeActionButton = (p: EligablePartyPart) =>
-    activePanel === 0 ? (
-      p.UserRevokedContractTime && p.StatusCategory === 'ongoing' ? (
+  const revokeActionButton = (p: EligablePartyPart) => {
+    if (p.UserRevokedContractTime && p.StatusCategory === 'ongoing') {
+      return (
         <Label rounded inverted color="warning">
           {t(`eligibility:permissions.table.currentAndClosed.status.revoking`)}
         </Label>
-      ) : (
-        <Button variant="tertiary" size={isMinLg ? 'sm' : 'lg'} onClick={handleRevokePermission(p)} className="flex-1">
-          {t('eligibility:permissions.table.currentAndClosed.revokeAction')}
-        </Button>
-      )
-    ) : (
-      closedLabel(p.StatusCategory)
+      );
+    }
+
+    return (
+      <Button variant="tertiary" size={isMinLg ? 'sm' : 'lg'} onClick={handleRevokePermission(p)} className="flex-1">
+        {t('eligibility:permissions.table.currentAndClosed.revokeAction')}
+      </Button>
     );
+  };
 
   const handleEndDate = (p: EligablePartyPart) => {
     if (p.StatusCategory === 'revoked') return p.UserRevokedContractTime;


### PR DESCRIPTION
# Pull Request

## Description

Replaces the Revoke button with a static Label while an agreement revocation is in progress.

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1419

## General Checklist

- [X] PR follows code style and standards
- [X] E2E tests (Cypress) have been executed, and new tests have been added if required
- [X] Project builds locally without errors
- [X] ESLint/Prettier have been run and are OK
- [X] API changes are documented (OpenAPI/README)
- [X] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [X] All affected pages render correctly (SSR/CSR)
- [X] Navigation works
- [X] API calls from the frontend continue to work
- [X] Any forms/flows function correctly
- [X] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [X] Affected endpoints behave as expected
- [X] No changes break existing contracts
- [X] Error handling works correctly
- [X] Logging behaves normally
- [X] Protected endpoints validated (auth/session/JWT)
