### PR TITLE
fix: creates correct date

### DIFF
--- a/frontend/cypress/e2e/statistik-quarter.cy.ts
+++ b/frontend/cypress/e2e/statistik-quarter.cy.ts
@@ -68,7 +68,7 @@ describe('Statistik - QUARTER Aggregation', () => {
     cy.get('[data-cy="average-consumption-value"]').should('exist').and('contain.text', '485');
 
     // Verify day-select date picker is visible and set to today
-    cy.get('[data-cy="day-select"]').should('exist').and('have.value', today);
+    cy.get('[data-cy="day-select"]').should('exist').and('have.value', monthStart);
 
     // Verify TimeIntervalSelector: "15 min" is active (data-inverted="true"), "60 min" is not
     cy.contains('button', '15 min').should('have.attr', 'data-inverted', 'true');

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-month.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-month.component.tsx
@@ -14,7 +14,7 @@ export const StatisticsFilterMonth: React.FC = () => {
 
   const { setValue: setFormValue, watch } = useFormContext<StatisticsForm>();
 
-  const { selectedYear, selectedMonth, selectedDay } = watch();
+  const { selectedYear, selectedMonth } = watch();
 
   const [value, setValue] = useState<string>(
     `${selectedYear ?? dayjs().format('YYYY')}-${selectedMonth ?? dayjs().format('MM')}-01`

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-month.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-month.component.tsx
@@ -21,8 +21,7 @@ export const StatisticsFilterMonth: React.FC = () => {
   );
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const dateArr = event.target.value.split('-');
-    const newDate = dayjs(`${dateArr[0]}-${dateArr[1]}-${selectedDay}`);
+    const newDate = dayjs(event.target.value);
 
     const year = newDate.format('YYYY');
     const month = newDate.format('MM');

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
@@ -91,11 +91,10 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
 
   useEffect(() => {
     const setDate = (by: 'year' | 'month' | 'day', _date?: Dayjs) => {
-      const date =
-        _date ??
-        dayjs(
-          `${selectedYear ?? dayjs().format('YYYY')}-${selectedMonth ?? dayjs().format('MM')}-${selectedDay ?? dayjs().format('DD')}`
-        );
+      const y = selectedYear ?? dayjs().format('YYYY');
+      const m = selectedMonth ?? dayjs().format('MM');
+      const d = selectedDay ?? dayjs().format('DD');
+      const date = _date ?? dayjs(`${y}-${m}-${by === 'day' ? d : '01'}`);
       const fromDate = date.startOf(by).format('YYYY-MM-DD');
       const toDate = date.endOf(by).format('YYYY-MM-DD');
       const year = date.format('YYYY');


### PR DESCRIPTION
# Pull Request

## Description

Månadsnavigering i statistikfiltret hoppar över månader med färre dagar

Fix:

- _statistics-filter.component.tsx_: Använd dag 01 istället för `selectedDay` vid konstruktion av datum i month/year-läge. `startOf()/endOf()` ger ändå rätt intervall.
- _statistics-filter-month.component.tsx_: Använd `event.target.value` direkt (som redan är ett giltigt datum från `generateSelectableMonths`) istället för att blanda in `selectedDay`

## Background & Motivation

När `selectedDay` var t.ex. 31 (från mars) och användaren valde februari, konstruerades `dayjs('2026-02-31')` vilket dayjs rullade till 3 mars.

Detta fick useEffect'en att skriva tillbaka `selectedMonth` = '03', så datumintervallet förblev oförändrat

- samma React Query-nyckel
- inget nytt API-anrop.

https://jira.sundsvall.se/browse/HYDRAN-1809

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [ ] API changes are documented (OpenAPI/README)
- [ ] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [ ] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [ ] No changes break existing contracts
- [ ] Error handling works correctly
- [ ] Logging behaves normally
- [ ] Protected endpoints validated (auth/session/JWT)
