### PR TITLE
fix: change timeInterval to 60min when change mode from day.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .env
 .DS_Store
 .vscode/launch.json
+CLAUDE.md
+.claude/settings.local.json

--- a/frontend/src/layouts/pages/mypages-sections/statistics/charts/consumption/consumption.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/charts/consumption/consumption.component.tsx
@@ -28,15 +28,24 @@ export interface ElectricityConsumptionProps {
 }
 
 export default function Consumption(props: ElectricityConsumptionProps) {
-  const { setValue } = useFormContext();
+  const { setValue, getValues, watch } = useFormContext();
   const { data, isFetching, isPreviousFetching, updateIsHourQuarter } = props;
   const [viewMode, setViewMode] = useState<EnumViewMode>(EnumViewMode.graph);
   const [timeInterval, setTimeInterval] = useState<EnumTimeInterval>(EnumTimeInterval.hour);
-  const { getValues } = useFormContext();
   const { t } = useTranslation('statistics');
 
   const showTimeInterval =
     dayjs(getValues().toDate).diff(getValues().fromDate, 'days') < 2 && data?.category === 'ELECTRICITY';
+
+  const isHourQuarter = watch('isHourQuarter');
+
+  useEffect(() => {
+    const expected = isHourQuarter ? EnumTimeInterval.quarter : EnumTimeInterval.hour;
+    if (timeInterval !== expected) {
+      setTimeInterval(expected);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHourQuarter]);
 
   useEffect(() => {
     if (updateIsHourQuarter) {

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
@@ -90,6 +90,12 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
   }, []);
 
   useEffect(() => {
+    if (mode !== 'day') {
+      setValue('isHourQuarter', false);
+    }
+  }, [mode, setValue]);
+
+  useEffect(() => {
     const setDate = (by: 'year' | 'month' | 'day', _date?: Dayjs) => {
       const date =
         _date ??


### PR DESCRIPTION
# Pull Request

## Description

### Summary

Fixes an issue where the `timeInterval` was not reset when switching away from **day** view mode in the statistics filter.

### Changes

#### `statistics-filter.component.tsx`
- Added a `useEffect` that resets `isHourQuarter` to `false` whenever the view mode changes away from `day`. This ensures the quarter-interval toggle is cleared when it is no longer applicable.

#### `consumption.component.tsx`
- Added a `useEffect` that watches `isHourQuarter` and syncs the local `timeInterval` state accordingly (`quarter` or `hour`), so the chart always reflects the correct interval when the form value changes externally.
- Cleaned up a duplicate `useFormContext()` call — `getValues`, `setValue`, and `watch` are now destructured from a single call.

#### `.gitignore`
- Added `CLAUDE.md` and `.claude/settings.local.json` to the ignore list.

### Related

Fixes HYDRAN-1811

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1811

## General Checklist

- [x] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
