### PR TITLE
Feat/hydran 1848 handle address filter agreements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 .env
 .DS_Store
 .vscode/launch.json
+
+.claude/
+CLAUDE.md

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -146,3 +146,7 @@ cert/
 
 # data contracts
 src/data-contracts/*/swagger.json
+
+# Claude AI
+.claude/
+CLAUDE.md

--- a/backend/src/controllers/agreement.controller.ts
+++ b/backend/src/controllers/agreement.controller.ts
@@ -5,12 +5,13 @@ import { RequestWithUser } from '@/interfaces/auth.interface';
 import { ApiResponse } from '@/interfaces/service';
 import ApiService from '@/services/api.service';
 import authMiddleware from '@middlewares/auth.middleware';
-import { Controller, Get, Param, Req, UseBefore } from 'routing-controllers';
+import { Controller, Get, Param, QueryParam, Req, UseBefore } from 'routing-controllers';
 import { OpenAPI } from 'routing-controllers-openapi';
 import { Agreement, AgreementResponse, Category } from '@/data-contracts/agreement/data-contracts';
 import { getRepresentingPartyId } from '@utils/getRepresentingPartyId';
 import dayjs from 'dayjs';
-import { fetchAgreementsForPartyAndDelegations } from '@/services/agreement.service';
+import { fetchAgreementsForPartyAndDelegations, fetchPagedAgreements } from '@/services/agreement.service';
+import { PagedAgreementsResult } from '@/interfaces/agreements.interface';
 
 function activeAgreement(agreement: Agreement): boolean {
   // Agreements are considered active if the `toDate` is in the future or undefined (ongoing agreements).
@@ -27,11 +28,16 @@ export class AgreementController {
   private apiService = new ApiService();
   private apiBase = getApiBase('agreement');
 
-  private async fetchAgreements(req: RequestWithUser, includeInactive: boolean): Promise<ApiResponse<Agreement[]>> {
+  private getSessionData(req: RequestWithUser) {
     const representing = req.session?.representing ?? undefined;
     const delegations = req?.session?.cache?.delegations ?? [];
     const partyId = getRepresentingPartyId(representing);
     const partyIdList: string[] = delegations.map(delegation => delegation.owner);
+    return { representing, delegations, partyId, partyIdList };
+  }
+
+  private async fetchAgreements(req: RequestWithUser, includeInactive: boolean): Promise<ApiResponse<Agreement[]>> {
+    const { partyId, partyIdList, delegations } = this.getSessionData(req);
 
     if (!partyId) {
       throw new HttpException(400, 'Bad Request');
@@ -50,7 +56,22 @@ export class AgreementController {
   @Get('/paged/agreements')
   @OpenAPI({ summary: 'Get agreements by party id' })
   @UseBefore(authMiddleware)
-  async getAgreements(@Req() req: RequestWithUser): Promise<ApiResponse<Agreement[]>> {
+  async getAgreements(
+    @Req() req: RequestWithUser,
+    @QueryParam('page') page?: number,
+    @QueryParam('limit') limit?: number,
+  ): Promise<ApiResponse<Agreement[] | PagedAgreementsResult>> {
+    if (page !== undefined) {
+      const { partyId, partyIdList, delegations } = this.getSessionData(req);
+
+      if (!partyId) {
+        throw new HttpException(400, 'No partyId found');
+      }
+
+      const data = await fetchPagedAgreements(partyId, partyIdList, delegations, req.user, page, limit ?? 100);
+      return { data, message: 'success' };
+    }
+
     return this.fetchAgreements(req, false);
   }
 

--- a/backend/src/interfaces/agreements.interface.ts
+++ b/backend/src/interfaces/agreements.interface.ts
@@ -1,0 +1,6 @@
+import { Agreement, PagingMetaData } from '@/data-contracts/agreement/data-contracts';
+
+export interface PagedAgreementsResult {
+  agreements: Agreement[];
+  _meta: PagingMetaData;
+}

--- a/backend/src/services/agreement.service.ts
+++ b/backend/src/services/agreement.service.ts
@@ -4,10 +4,29 @@ import { Agreement, AgreementParameters, PagedAgreementResponse } from '@/data-c
 import { Delegation } from '@/data-contracts/installedbase/data-contracts';
 import ApiService from './api.service';
 import dayjs from 'dayjs';
+import { PagedAgreementsResult } from '@/interfaces/agreements.interface';
 
 function activeAgreement(agreement: Agreement): boolean {
   // Agreements are considered active if the `toDate` is in the future or undefined (ongoing agreements).
   return dayjs(agreement.toDate).isAfter(dayjs()) || agreement.toDate === undefined;
+}
+
+async function fetchAllAgreementPages(
+  apiService: ApiService,
+  url: string,
+  user: { username: string },
+): Promise<Agreement[]> {
+  const allAgreements: Agreement[] = [];
+  let totalPages = 1;
+
+  for (let page = 1; page <= totalPages; page++) {
+    const params: AgreementParameters = { limit: 1000, page };
+    const res = await apiService.get<PagedAgreementResponse>({ url, params }, user);
+    allAgreements.push(...(res.data.agreements ?? []));
+    totalPages = res.data._meta?.totalPages ?? 1;
+  }
+
+  return allAgreements;
 }
 
 export const fetchAgreementsForPartyAndDelegations = async (
@@ -19,13 +38,11 @@ export const fetchAgreementsForPartyAndDelegations = async (
 ): Promise<Agreement[]> => {
   const apiService = new ApiService();
   const apiBase = getApiBase('agreement');
-  const url = `${apiBase}/${MUNICIPALITY_ID}/paged/agreements/${partyId}`;
-  const params: AgreementParameters = { limit: 1000, page: 1 };
   const filteredAgreements: Agreement[] = [];
   const agreements: Agreement[] = [];
 
-  const res = await apiService.get<PagedAgreementResponse>({ url, params }, user);
-  let mainAgreements = res.data.agreements;
+  const mainUrl = `${apiBase}/${MUNICIPALITY_ID}/paged/agreements/${partyId}`;
+  let mainAgreements = await fetchAllAgreementPages(apiService, mainUrl, user);
   if (!includeInactiveAgreements) {
     mainAgreements = mainAgreements.filter(activeAgreement);
   }
@@ -33,10 +50,10 @@ export const fetchAgreementsForPartyAndDelegations = async (
 
   for (const partyId of partyIdList) {
     const delegationUrl = `${apiBase}/${MUNICIPALITY_ID}/paged/agreements/${partyId}`;
-    const { data: delegationData } = await apiService.get<PagedAgreementResponse>({ url: delegationUrl, params }, user);
+    const allDelegationAgreements = await fetchAllAgreementPages(apiService, delegationUrl, user);
     const delegationAgreements = includeInactiveAgreements
-      ? delegationData.agreements
-      : delegationData.agreements.filter(activeAgreement);
+      ? allDelegationAgreements
+      : allDelegationAgreements.filter(activeAgreement);
 
     agreements.push(...delegationAgreements);
   }
@@ -51,4 +68,43 @@ export const fetchAgreementsForPartyAndDelegations = async (
   });
 
   return filteredAgreements;
+};
+
+export const fetchPagedAgreements = async (
+  partyId: string,
+  partyIdList: string[],
+  delegations: Delegation[],
+  user: { username: string },
+  page: number,
+  limit: number,
+): Promise<PagedAgreementsResult> => {
+  const apiService = new ApiService();
+  const apiBase = getApiBase('agreement');
+
+  const mainUrl = `${apiBase}/${MUNICIPALITY_ID}/paged/agreements/${partyId}`;
+  const params: AgreementParameters = { limit, page };
+  const res = await apiService.get<PagedAgreementResponse>({ url: mainUrl, params }, user);
+
+  let agreements = (res.data.agreements ?? []).filter(activeAgreement);
+
+  if (page === 1) {
+    const delegationAgreements: Agreement[] = [];
+
+    for (const delegationPartyId of partyIdList) {
+      const delegationUrl = `${apiBase}/${MUNICIPALITY_ID}/paged/agreements/${delegationPartyId}`;
+      const allDelegationAgreements = await fetchAllAgreementPages(apiService, delegationUrl, user);
+      delegationAgreements.push(...allDelegationAgreements.filter(activeAgreement));
+    }
+
+    const matchedDelegationAgreements = delegationAgreements.filter(agreement =>
+      delegations.some(delegation => delegation.facilities.some(facility => facility.id === agreement.facilityId)),
+    );
+
+    agreements = [...agreements, ...matchedDelegationAgreements];
+  }
+
+  return {
+    agreements,
+    _meta: res.data._meta ?? { page, limit, totalPages: 1 },
+  };
 };

--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -46,6 +46,13 @@ export const setIntercepts = (
   cy.intercept('GET', '**/api/businessengagements', getBusinessEngagements).as('getBusinessEngagements');
   cy.intercept('GET', '**/api/myrelations', getMyRelations).as('getMyRelations');
   cy.intercept('GET', '**/api/paged/agreements', getMyPagedAgreements()).as('getMyPagedAgreements');
+  cy.intercept('GET', '**/api/paged/agreements?page=*', {
+    data: {
+      agreements: getMyPagedAgreements().data,
+      _meta: { page: 1, limit: 100, totalPages: 1 },
+    },
+    message: 'success',
+  }).as('getMyPagedAgreementsPages');
   cy.intercept('GET', '**/api/contactsettings', getContactSettings(representingMode)).as('getContactSettings');
 
   cy.intercept('GET', '**/api/delegates', getDelegates()).as('getDelegates');

--- a/frontend/locales/sv/overview.json
+++ b/frontend/locales/sv/overview.json
@@ -4,6 +4,7 @@
     "description": "Visar din förbrukning och produktion för {{month}}.",
     "noConsumption": "Det finns ingen förbrukning att visa.",
     "fetchingPagesStatus": "Kontrollerar om adresser har avtal. Sida {{currentPage}} från avtal.",
+    "agreementsError": "Kunde inte hämta avtal att kontrollera mot adresser",
     "card": {
       "noData": "Det går inte att hitta någon data för perioden.",
       "unit": "kWh",

--- a/frontend/locales/sv/overview.json
+++ b/frontend/locales/sv/overview.json
@@ -3,6 +3,7 @@
     "title": "Aktuell förbrukning och produktion",
     "description": "Visar din förbrukning och produktion för {{month}}.",
     "noConsumption": "Det finns ingen förbrukning att visa.",
+    "fetchingPagesStatus": "Kontrollerar om adresser har avtal. Sida {{currentPage}} från avtal.",
     "card": {
       "noData": "Det går inte att hitta någon data för perioden.",
       "unit": "kWh",

--- a/frontend/locales/sv/overview.json
+++ b/frontend/locales/sv/overview.json
@@ -3,7 +3,6 @@
     "title": "Aktuell förbrukning och produktion",
     "description": "Visar din förbrukning och produktion för {{month}}.",
     "noConsumption": "Det finns ingen förbrukning att visa.",
-    "fetchingPagesStatus": "Kontrollerar om adresser har avtal. Sida {{currentPage}} från avtal.",
     "agreementsError": "Kunde inte hämta avtal att kontrollera mot adresser",
     "card": {
       "noData": "Det går inte att hitta någon data för perioden.",

--- a/frontend/src/interfaces/agreement.ts
+++ b/frontend/src/interfaces/agreement.ts
@@ -51,3 +51,16 @@ export interface RefinedAgreement extends Omit<Agreement, 'category'> {
 export interface AgreementData {
   [siteAddress: string]: RefinedAgreement[];
 }
+
+export interface PagingMetaData {
+  page?: number;
+  limit?: number;
+  count?: number;
+  totalRecords?: number;
+  totalPages?: number;
+}
+
+export interface PagedAgreementsResponse {
+  agreements: Agreement[];
+  _meta: PagingMetaData;
+}

--- a/frontend/src/layouts/pages/mypages-sections/overview/consumption/consumption.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/overview/consumption/consumption.component.tsx
@@ -24,15 +24,14 @@ export const Consumption = () => {
     isFetching: isAgreementsFetching,
     isDone: isAgreementsDone,
     currentPage,
+    error: agreementsError,
   } = usePagedAgreements(200);
 
   const [address, setAddress] = useState<string>();
   const [facilities, setFacilities] = useState<InstalledBaseItem[]>();
   const [hasInitialAddress, setHasInitialAddress] = useState(false);
   const { t } = useTranslation(['common', 'overview']);
-
-  const hasAgreement = (a: FacilityAddress) => Boolean(a.address && agreements?.[a.address]?.length);
-
+  const hasAgreement = (a: FacilityAddress) => a.address && agreements?.[a.address]?.length;
   const addressesWithAgreements = user?.addresses?.filter(hasAgreement) ?? [];
 
   useEffect(() => {
@@ -65,9 +64,16 @@ export const Consumption = () => {
   }, [agreements, address, user]);
 
   const thisMonth = dayjs();
-
   const isLoading = isUserFetching || (isAgreementsFetching && addressesWithAgreements.length === 0);
   const hasData = user && addressesWithAgreements.length > 0 && facilities?.length;
+
+  if (agreementsError) {
+    return (
+      <div className="mb-16">
+        <p>{t('overview:consumption.agreementsError')}</p>
+      </div>
+    );
+  }
 
   const consumption = hasData ? (
     <div>

--- a/frontend/src/layouts/pages/mypages-sections/overview/consumption/consumption.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/overview/consumption/consumption.component.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ConsumptionCard } from '@layouts/pages/mypages-sections/overview/consumption/consumption-card.component';
-import { Select, Spinner } from '@sk-web-gui/react';
+import { ProgressBar, Select, Spinner } from '@sk-web-gui/react';
 import { useApi } from '@services/api-service';
 import { User } from '@interfaces/user';
 import { useEffect, useState } from 'react';
@@ -24,8 +24,9 @@ export const Consumption = () => {
     isFetching: isAgreementsFetching,
     isDone: isAgreementsDone,
     currentPage,
+    totalPages,
     error: agreementsError,
-  } = usePagedAgreements(200);
+  } = usePagedAgreements(20);
 
   const [address, setAddress] = useState<string>();
   const [facilities, setFacilities] = useState<InstalledBaseItem[]>();
@@ -93,9 +94,8 @@ export const Consumption = () => {
         </div>
       )}
       {!isAgreementsDone && (
-        <div className="flex items-center gap-8 mb-16">
-          <Spinner size={2} />
-          <p className="text-small"> {t('overview:consumption.fetchingPagesStatus', { currentPage })}</p>
+        <div className="flex gap-8 mb-24 w-1/2 pr-24">
+          <ProgressBar current={currentPage} steps={totalPages} size="md" color="vattjom" className="w-full" />
         </div>
       )}
       <div className="w-full md:flex md:flex-wrap md:gap-24 block" data-cy="consumption-card-wrapper">

--- a/frontend/src/layouts/pages/mypages-sections/overview/consumption/consumption.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/overview/consumption/consumption.component.tsx
@@ -7,10 +7,10 @@ import { User } from '@interfaces/user';
 import { useEffect, useState } from 'react';
 import { InstalledBaseItem } from '@data-contracts/installedbase/data-contracts';
 import dayjs from 'dayjs';
-import { pagedAgreementsHandler } from '@services/agreement-service';
 import { RefinedAgreement } from '@interfaces/agreement';
 import { FacilityAddress } from '@interfaces/facility-address';
 import { useTranslation } from 'react-i18next';
+import { usePagedAgreements } from '@utils/use-paged-agreements.hook';
 
 export const Consumption = () => {
   const { data: user, isFetching: isUserFetching } = useApi<User>({
@@ -19,27 +19,31 @@ export const Consumption = () => {
     queryKey: ['user'],
   });
 
-  const { data: agreements, isFetching: isAgreementsFetching } = useApi({
-    url: `/paged/agreements`,
-    method: 'get',
-    dataHandler: pagedAgreementsHandler,
-  });
+  const {
+    agreements,
+    isFetching: isAgreementsFetching,
+    isDone: isAgreementsDone,
+    currentPage,
+  } = usePagedAgreements(200);
 
   const [address, setAddress] = useState<string>();
   const [facilities, setFacilities] = useState<InstalledBaseItem[]>();
-  const [isFiltering, setIsFiltering] = useState<boolean>(false);
+  const [hasInitialAddress, setHasInitialAddress] = useState(false);
   const { t } = useTranslation(['common', 'overview']);
 
   const hasAgreement = (a: FacilityAddress) => Boolean(a.address && agreements?.[a.address]?.length);
 
-  useEffect(() => {
-    setAddress(user?.addresses?.filter(hasAgreement)?.[0]?.address ?? '');
-    setIsFiltering(true);
-    //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, agreements]);
+  const addressesWithAgreements = user?.addresses?.filter(hasAgreement) ?? [];
 
   useEffect(() => {
-    if (user && agreements) {
+    if (!hasInitialAddress && addressesWithAgreements.length > 0) {
+      setAddress(addressesWithAgreements[0]?.address ?? '');
+      setHasInitialAddress(true);
+    }
+  }, [addressesWithAgreements, hasInitialAddress]);
+
+  useEffect(() => {
+    if (user && address && agreements) {
       let filteredFacilities: InstalledBaseItem[] = [];
       for (const agreementAddress in agreements) {
         if (agreementAddress === address) {
@@ -57,47 +61,51 @@ export const Consumption = () => {
         }
       }
       setFacilities(filteredFacilities);
-      setIsFiltering(false);
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agreements, address, user]);
 
   const thisMonth = dayjs();
 
-  const consumption =
-    user && facilities?.length ? (
-      <div>
-        <p className="text-large mb-32">
-          {t('overview:consumption.description', { month: thisMonth.format('MMMM YYYY').toLowerCase() })}
-        </p>
-        {user.addresses?.filter(hasAgreement).length > 1 && (
-          <div className="sm:flex sm:flex-row flex-nowrap items-center pb-24 gap-16 block">
-            <strong>{t('common:address')}</strong>
-            <Select className="sm:w-auto sm:mt-0 mt-8 w-full" onChange={(e) => setAddress(e.target.value)} size="sm">
-              {user.addresses?.filter(hasAgreement).map((address) => (
-                <Select.Option key={address?.address ?? 'unknown'}>
-                  {address?.address ? address.address : t('common:unknownAddress')}
-                </Select.Option>
-              ))}
-            </Select>
-          </div>
-        )}
-        <div className="w-full md:flex md:flex-wrap md:gap-24 block" data-cy="consumption-card-wrapper">
-          {facilities?.map((facility) => {
-            return <ConsumptionCard key={facility.facilityId} facility={facility} date={thisMonth} />;
-          })}
+  const isLoading = isUserFetching || (isAgreementsFetching && addressesWithAgreements.length === 0);
+  const hasData = user && addressesWithAgreements.length > 0 && facilities?.length;
+
+  const consumption = hasData ? (
+    <div>
+      <p className="text-large mb-32">
+        {t('overview:consumption.description', { month: thisMonth.format('MMMM YYYY').toLowerCase() })}
+      </p>
+      {addressesWithAgreements.length > 1 && (
+        <div className="sm:flex sm:flex-row flex-nowrap items-center pb-24 gap-16 block">
+          <strong>{t('common:address')}</strong>
+          <Select className="sm:w-auto sm:mt-0 mt-8 w-full" onChange={(e) => setAddress(e.target.value)} size="sm">
+            {addressesWithAgreements.map((addr) => (
+              <Select.Option key={addr?.address ?? 'unknown'}>
+                {addr?.address ? addr.address : t('common:unknownAddress')}
+              </Select.Option>
+            ))}
+          </Select>
         </div>
+      )}
+      {!isAgreementsDone && (
+        <div className="flex items-center gap-8 mb-16">
+          <Spinner size={2} />
+          <p className="text-small"> {t('overview:consumption.fetchingPagesStatus', { currentPage })}</p>
+        </div>
+      )}
+      <div className="w-full md:flex md:flex-wrap md:gap-24 block" data-cy="consumption-card-wrapper">
+        {facilities?.map((facility) => {
+          return <ConsumptionCard key={facility.facilityId} facility={facility} date={thisMonth} />;
+        })}
       </div>
-    ) : (
-      <p>{t('overview:consumption.noConsumption')}</p>
-    );
+    </div>
+  ) : isAgreementsDone ? (
+    <p>{t('overview:consumption.noConsumption')}</p>
+  ) : null;
 
   return (
     <section className="pb-80 visible">
       <h1>{t('overview:consumption.title')}</h1>
-
-      {isUserFetching || isAgreementsFetching || isFiltering ? <Spinner className="mx-auto" /> : consumption}
+      {isLoading ? <Spinner className="mx-auto" /> : consumption}
     </section>
   );
 };

--- a/frontend/src/utils/use-paged-agreements.hook.ts
+++ b/frontend/src/utils/use-paged-agreements.hook.ts
@@ -8,6 +8,7 @@ export function usePagedAgreements(pageLimit: number) {
   const [isFetching, setIsFetching] = useState(true);
   const [isDone, setIsDone] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
   const [error, setError] = useState<Error | null>(null);
 
   const mergeAgreements = useCallback((incoming: AgreementData, prev: AgreementData): AgreementData => {
@@ -37,6 +38,7 @@ export function usePagedAgreements(pageLimit: number) {
           setCurrentPage(page);
 
           totalPages = pageData._meta?.totalPages ?? 1;
+          setTotalPages(totalPages);
         }
       } catch (e) {
         if (!cancelled) {
@@ -57,5 +59,5 @@ export function usePagedAgreements(pageLimit: number) {
     };
   }, [mergeAgreements]);
 
-  return { agreements, isFetching, isDone, currentPage, error };
+  return { agreements, isFetching, isDone, currentPage, totalPages, error };
 }

--- a/frontend/src/utils/use-paged-agreements.hook.ts
+++ b/frontend/src/utils/use-paged-agreements.hook.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AgreementData, PagedAgreementsResponse } from '@interfaces/agreement';
+import { handlePagedAgreementsResponse } from '@services/agreement-service';
+import { apiService, ApiResponse } from '@services/api-service';
+
+export function usePagedAgreements(pageLimit: number) {
+  const [agreements, setAgreements] = useState<AgreementData>({});
+  const [isFetching, setIsFetching] = useState(true);
+  const [isDone, setIsDone] = useState(false);
+  const [currentPage, setCurrentPage] = useState(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const mergeAgreements = useCallback((incoming: AgreementData, prev: AgreementData): AgreementData => {
+    const merged = { ...prev };
+    for (const address in incoming) {
+      merged[address] = [...(merged[address] ?? []), ...incoming[address]];
+    }
+    return merged;
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    const fetchPages = async () => {
+      let page = 1;
+      let totalPages = 1;
+
+      try {
+        while (page <= totalPages && !controller.signal.aborted) {
+          const res = await apiService.get<ApiResponse<PagedAgreementsResponse>>(
+            `/paged/agreements?page=${page}&limit=${pageLimit}`,
+            { signal: controller.signal }
+          );
+
+          const pageData = res.data.data;
+          const refined = handlePagedAgreementsResponse(pageData.agreements);
+
+          setAgreements((prev) => mergeAgreements(refined, prev));
+          setCurrentPage(page);
+
+          totalPages = pageData._meta?.totalPages ?? 1;
+          page++;
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          console.error('Failed to fetch agreements page');
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsFetching(false);
+          setIsDone(true);
+        }
+      }
+    };
+
+    fetchPages();
+
+    return () => {
+      controller.abort();
+    };
+  }, [mergeAgreements]);
+
+  return { agreements, isFetching, isDone, currentPage };
+}

--- a/frontend/src/utils/use-paged-agreements.hook.ts
+++ b/frontend/src/utils/use-paged-agreements.hook.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AgreementData, PagedAgreementsResponse } from '@interfaces/agreement';
 import { handlePagedAgreementsResponse } from '@services/agreement-service';
 import { apiService, ApiResponse } from '@services/api-service';
@@ -8,7 +8,7 @@ export function usePagedAgreements(pageLimit: number) {
   const [isFetching, setIsFetching] = useState(true);
   const [isDone, setIsDone] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
-  const abortControllerRef = useRef<AbortController | null>(null);
+  const [error, setError] = useState<Error | null>(null);
 
   const mergeAgreements = useCallback((incoming: AgreementData, prev: AgreementData): AgreementData => {
     const merged = { ...prev };
@@ -19,18 +19,15 @@ export function usePagedAgreements(pageLimit: number) {
   }, []);
 
   useEffect(() => {
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
+    let cancelled = false;
 
     const fetchPages = async () => {
-      let page = 1;
       let totalPages = 1;
 
       try {
-        while (page <= totalPages && !controller.signal.aborted) {
+        for (let page = 1; page <= totalPages && !cancelled; page++) {
           const res = await apiService.get<ApiResponse<PagedAgreementsResponse>>(
-            `/paged/agreements?page=${page}&limit=${pageLimit}`,
-            { signal: controller.signal }
+            `/paged/agreements?page=${page}&limit=${pageLimit}`
           );
 
           const pageData = res.data.data;
@@ -40,26 +37,25 @@ export function usePagedAgreements(pageLimit: number) {
           setCurrentPage(page);
 
           totalPages = pageData._meta?.totalPages ?? 1;
-          page++;
         }
-      } catch {
-        if (!controller.signal.aborted) {
-          console.error('Failed to fetch agreements page');
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e : new Error('Failed to fetch agreements page'));
         }
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsFetching(false);
-          setIsDone(true);
-        }
+      }
+
+      if (!cancelled) {
+        setIsFetching(false);
+        setIsDone(true);
       }
     };
 
     fetchPages();
 
     return () => {
-      controller.abort();
+      cancelled = true;
     };
   }, [mergeAgreements]);
 
-  return { agreements, isFetching, isDone, currentPage };
+  return { agreements, isFetching, isDone, currentPage, error };
 }


### PR DESCRIPTION
# Pull Request

## Description

Användare med många avtal fick vänta tills alla avtal hämtats innan adress-dropdown på översikten kunde visas. BE hämtade samtliga sidor internt (1000 per sida - limit) och returnerade allt i ett enda svar. FE kunde alltså inte visa något förrän allt var hämtat.

Lösningen - "progressiv" laddning

FE hämtar avtal/agreements sida-för-sida (200 åt gången - skickas in som parameter till hook'en) och visar adresser i dropdown så fort de dyker upp i svaret. Användaren får en indikation på hur många sidor som har lästs in

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1848

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
