### PR TITLE
fix: set min and max limits for datepickers (in export modal)

### DIFF
--- a/frontend/src/layouts/pages/mypages-sections/statistics/export-statistics-button/custom-date-picker.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/export-statistics-button/custom-date-picker.component.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, useRef, useMemo } from 'react';
+import { ChangeEvent, useRef, useMemo, KeyboardEvent } from 'react';
 import { DatePicker, Icon, Input, Select } from '@sk-web-gui/react';
 import { generateSelectableYears } from '@layouts/pages/mypages-sections/statistics/statistics-filter/generateDateLists';
 import dayjs from 'dayjs';
@@ -15,6 +15,12 @@ interface CustomDatePickerProps {
 export const CustomDatePicker = ({ type, value, onChange }: CustomDatePickerProps) => {
   const selectableYears = useMemo(() => generateSelectableYears(dayjs().format('YYYY-MM-DD')), []);
   const monthInputRef = useRef<HTMLInputElement>(null);
+
+  const preventTyping = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Tab') {
+      e.preventDefault();
+    }
+  };
 
   if (type === 'year') {
     return (
@@ -40,6 +46,9 @@ export const CustomDatePicker = ({ type, value, onChange }: CustomDatePickerProp
       <DatePicker
         type="date"
         value={value}
+        min={dayjs().subtract(3, 'year').format('YYYY-MM-DD')}
+        max={dayjs().format('YYYY-MM-DD')}
+        onKeyDown={preventTyping}
         onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
         className="self-stretch"
       />
@@ -51,9 +60,12 @@ export const CustomDatePicker = ({ type, value, onChange }: CustomDatePickerProp
       <Input
         ref={monthInputRef}
         type="month"
+        min={dayjs().subtract(3, 'year').format('YYYY-MM')}
+        max={dayjs().format('YYYY-MM')}
         value={value}
         onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
         className="self-stretch"
+        onKeyDown={preventTyping}
       />
       <Input.RightAddin icon onClick={() => monthInputRef.current?.showPicker()}>
         <Icon icon={<Calendar />} size="17px" />


### PR DESCRIPTION
# Pull Request

## Description
### Summary
- Added min/max date constraints to statistics export date pickers (3 years back to today)
- Prevented manual keyboard input to ensure users select valid dates via the picker

### Acceptance Criteria
-  Verify date picker only allows dates within the last 3 years
-  Verify month picker only allows months within the last 3 years
-  Confirm typing is blocked (except Tab for navigation)
-  Test that clicking the calendar icon still opens the picker
-  Verify selected dates are correctly formatted and submitted


## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1913

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
