### PR TITLE
Fix/hydran 1944 batch measurementdata calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Dessa APIer används i projektet, applikationsanvändaren i WSO2 måste prenumerera på dessa.
 
 | API               | Version |
-| ----------------- |--------:|
+| ----------------- | ------: |
 | ContactSettings   |     2.0 |
 | Citizen           |     3.0 |
 | Disturbances      |     5.0 |
@@ -14,7 +14,7 @@ Dessa APIer används i projektet, applikationsanvändaren i WSO2 måste prenumer
 | Customer          |     4.0 |
 | Installedbase     |     3.1 |
 | Agreement         |     4.1 |
-| MeasurementData   |     3.1 |
+| MeasurementData   |     3.3 |
 | MyRepresentatives |     4.2 |
 | LegalEntity       |     2.0 |
 | Eventlog          |     2.1 |

--- a/backend/src/config/api-config.ts
+++ b/backend/src/config/api-config.ts
@@ -34,7 +34,7 @@ export const APIS = [
   },
   {
     name: 'measurementdata',
-    version: '3.1',
+    version: '3.3',
   },
   {
     name: 'simulatorserver',

--- a/backend/src/controllers/measurement-data.controller.ts
+++ b/backend/src/controllers/measurement-data.controller.ts
@@ -1,8 +1,10 @@
 import { MUNICIPALITY_ID } from '@/config';
 import { getApiBase } from '@/config/api-config';
+import { Delegation } from '@/data-contracts/installedbase/data-contracts';
 import { Data } from '@/data-contracts/measurementdata/data-contracts';
 import { HttpException } from '@/exceptions/HttpException';
 import { RequestWithUser } from '@/interfaces/auth.interface';
+import { RepresentingEntity } from '@/interfaces/representing.interface';
 import ApiService from '@/services/api.service';
 import authMiddleware from '@middlewares/auth.middleware';
 import { Controller, Get, Req, UseBefore } from 'routing-controllers';
@@ -22,20 +24,17 @@ export class MeasurementDataController {
     const representing = req.session?.representing ?? undefined;
     const delegations = req.session?.cache?.delegations ?? [];
     const { category, facilityIds, fromDate, toDate, aggregateOn } = req.query;
-    const facilityIdList = Array.isArray(facilityIds)
-      ? (facilityIds as string[])
-      : facilityIds
-        ? [facilityIds as string]
-        : [];
-    let partyId = getRepresentingPartyId(representing);
+    const facilityIdList = [facilityIds ?? []].flat() as string[];
 
-    delegations.forEach(delegation => {
-      delegation.facilities.forEach(facility => {
-        if (facilityIdList.includes(facility.id)) {
-          partyId = delegation.owner;
-        }
-      });
-    });
+    const resolvePartyId = (
+      representing: RepresentingEntity,
+      delegations: Delegation[],
+      facilityIdList: string[],
+    ): string | undefined => {
+      const matchingDelegation = delegations.find(d => d.facilities.some(f => facilityIdList.includes(f.id)));
+      return matchingDelegation?.owner ?? getRepresentingPartyId(representing);
+    };
+    const partyId = resolvePartyId(representing, delegations, facilityIdList);
 
     if (!partyId) {
       throw new HttpException(400, 'Bad Request');

--- a/backend/src/controllers/measurement-data.controller.ts
+++ b/backend/src/controllers/measurement-data.controller.ts
@@ -21,12 +21,17 @@ export class MeasurementDataController {
   async getMeasurementData(@Req() req: RequestWithUser): Promise<ApiResponse<Data>> {
     const representing = req.session?.representing ?? undefined;
     const delegations = req.session?.cache?.delegations ?? [];
-    const { category, facilityId, fromDate, toDate, aggregateOn } = req.query;
+    const { category, facilityIds, fromDate, toDate, aggregateOn } = req.query;
+    const facilityIdList = Array.isArray(facilityIds)
+      ? (facilityIds as string[])
+      : facilityIds
+        ? [facilityIds as string]
+        : [];
     let partyId = getRepresentingPartyId(representing);
 
     delegations.forEach(delegation => {
       delegation.facilities.forEach(facility => {
-        if (facility.id === facilityId) {
+        if (facilityIdList.includes(facility.id)) {
           partyId = delegation.owner;
         }
       });
@@ -41,7 +46,7 @@ export class MeasurementDataController {
       const params = {
         partyId,
         category,
-        facilityIds: facilityId ? [facilityId] : [],
+        facilityIds: facilityIdList,
         fromDate,
         toDate,
         aggregateOn,

--- a/backend/src/data-contracts/eventlog/data-contracts.ts
+++ b/backend/src/data-contracts/eventlog/data-contracts.ts
@@ -143,10 +143,11 @@ export interface PageEvent {
   content?: Event[];
   /** @format int32 */
   number?: number;
-  /** @format int32 */
-  numberOfElements?: number;
   first?: boolean;
   last?: boolean;
+  pageable?: PageableObject;
+  /** @format int32 */
+  numberOfElements?: number;
   sort?: SortObject;
   empty?: boolean;
 }
@@ -159,8 +160,8 @@ export interface PageableObject {
   pageNumber?: number;
   /** @format int32 */
   pageSize?: number;
-  unpaged?: boolean;
   sort?: SortObject;
+  unpaged?: boolean;
 }
 
 export interface SortObject {

--- a/backend/src/data-contracts/installedbase/data-contracts.ts
+++ b/backend/src/data-contracts/installedbase/data-contracts.ts
@@ -14,8 +14,8 @@ export interface Problem {
   instance?: string;
   /** @format uri */
   type?: string;
-  title?: string;
   detail?: string;
+  title?: string;
   /** @format int32 */
   status?: number;
 }
@@ -80,6 +80,116 @@ export interface UpdateDelegation {
   facilities?: Facility[];
   /** Party ID of the delegate */
   delegatedTo?: string;
+}
+
+export interface InstalledBaseParameters {
+  /**
+   * Page number
+   * @format int32
+   * @min 1
+   * @default 1
+   */
+  page?: number;
+  /**
+   * Result size per page. Maximum allowed value is dynamically configured
+   * @format int32
+   * @min 1
+   */
+  limit?: number;
+  /** UUID that represents a party */
+  partyId?: string;
+  /** List of organization ids */
+  organizationIds?: string[];
+  /**
+   * Filter date
+   * @format date
+   */
+  date?: string;
+  /** Column to sort by */
+  sortBy?: string;
+}
+
+export enum Direction {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+/** Installed base model */
+export interface InstalledBase {
+  /** Company */
+  company?: string;
+  /** Customer number */
+  customerId?: string;
+  /** type */
+  type?: string;
+  /** Facility id */
+  facilityId?: string;
+  /** Placement id */
+  placementId?: string;
+  /** Care of */
+  careOf?: string;
+  /** Street */
+  street?: string;
+  /** Postal code */
+  postCode?: string;
+  /** City */
+  city?: string;
+  /** Property designation */
+  propertyDesignation?: string;
+  /**
+   * Date from
+   * @format date
+   */
+  dateFrom?: string;
+  /**
+   * Date to
+   * @format date
+   */
+  dateTo?: string;
+  /**
+   * Last modified date
+   * @format date
+   */
+  dateLatestModified?: string;
+}
+
+/** Installed bases response model */
+export interface InstalledBases {
+  installedBaseList?: InstalledBase[];
+  /** PagingAndSortingMetaData model */
+  _meta?: PagingAndSortingMetaData;
+}
+
+/** PagingAndSortingMetaData model */
+export interface PagingAndSortingMetaData {
+  /**
+   * Current page
+   * @format int32
+   */
+  page?: number;
+  /**
+   * Displayed objects per page
+   * @format int32
+   */
+  limit?: number;
+  /**
+   * Displayed objects on current page
+   * @format int32
+   */
+  count?: number;
+  /**
+   * Total amount of hits based on provided search parameters
+   * @format int64
+   */
+  totalRecords?: number;
+  /**
+   * Total amount of pages based on provided search parameters
+   * @format int32
+   */
+  totalPages?: number;
+  sortBy?: string[];
+  /** The sort order direction */
+  sortDirection?: Direction;
 }
 
 /** Installed base owner model */

--- a/backend/src/data-contracts/invoices/data-contracts.ts
+++ b/backend/src/data-contracts/invoices/data-contracts.ts
@@ -238,35 +238,97 @@ export interface Problem {
   instance?: string;
   /** @format uri */
   type?: string;
+  parameters?: Record<string, any>;
+  status?: StatusType;
   title?: string;
   detail?: string;
+}
+
+export interface StatusType {
   /** @format int32 */
-  status?: number;
+  statusCode?: number;
+  reasonPhrase?: string;
 }
 
 export interface ConstraintViolationProblem {
+  cause?: ThrowableProblem;
+  stackTrace?: {
+    classLoaderName?: string;
+    moduleName?: string;
+    moduleVersion?: string;
+    methodName?: string;
+    fileName?: string;
+    /** @format int32 */
+    lineNumber?: number;
+    className?: string;
+    nativeMethod?: boolean;
+  }[];
   /** @format uri */
   type?: string;
-  /** @format int32 */
-  status?: number;
+  status?: StatusType;
   violations?: Violation[];
   title?: string;
+  message?: string;
   /** @format uri */
   instance?: string;
+  parameters?: Record<string, any>;
   detail?: string;
-  causeAsProblem?: ThrowableProblem;
+  suppressed?: {
+    stackTrace?: {
+      classLoaderName?: string;
+      moduleName?: string;
+      moduleVersion?: string;
+      methodName?: string;
+      fileName?: string;
+      /** @format int32 */
+      lineNumber?: number;
+      className?: string;
+      nativeMethod?: boolean;
+    }[];
+    message?: string;
+    localizedMessage?: string;
+  }[];
+  localizedMessage?: string;
 }
 
 export interface ThrowableProblem {
-  /** @format uri */
-  type?: string;
-  title?: string;
-  /** @format int32 */
-  status?: number;
-  detail?: string;
+  cause?: any;
+  stackTrace?: {
+    classLoaderName?: string;
+    moduleName?: string;
+    moduleVersion?: string;
+    methodName?: string;
+    fileName?: string;
+    /** @format int32 */
+    lineNumber?: number;
+    className?: string;
+    nativeMethod?: boolean;
+  }[];
+  message?: string;
   /** @format uri */
   instance?: string;
-  causeAsProblem?: any;
+  /** @format uri */
+  type?: string;
+  parameters?: Record<string, any>;
+  status?: StatusType;
+  title?: string;
+  detail?: string;
+  suppressed?: {
+    stackTrace?: {
+      classLoaderName?: string;
+      moduleName?: string;
+      moduleVersion?: string;
+      methodName?: string;
+      fileName?: string;
+      /** @format int32 */
+      lineNumber?: number;
+      className?: string;
+      nativeMethod?: boolean;
+    }[];
+    message?: string;
+    localizedMessage?: string;
+  }[];
+  localizedMessage?: string;
 }
 
 export interface Violation {

--- a/backend/src/data-contracts/measurementdata/data-contracts.ts
+++ b/backend/src/data-contracts/measurementdata/data-contracts.ts
@@ -31,6 +31,8 @@ export interface MeasurementPoint {
 
 /** Measurement from a single source */
 export interface MeasurementSerie {
+  /** Facility ID for non-aggregated series, null for aggregated */
+  facilityId?: string;
   /** Unit of all measurement points */
   unit?: string;
   /** Type of measurement */
@@ -49,6 +51,7 @@ export enum Aggregation {
 
 /** Category */
 export enum Category {
+  DISTRICT_COOLING = 'DISTRICT_COOLING',
   DISTRICT_HEATING = 'DISTRICT_HEATING',
   ELECTRICITY = 'ELECTRICITY',
   COMMUNICATION = 'COMMUNICATION',
@@ -118,6 +121,7 @@ export interface Violation {
 
 /** Category */
 export enum GetMeasurementDataParamsCategoryEnum {
+  DISTRICT_COOLING = 'DISTRICT_COOLING',
   DISTRICT_HEATING = 'DISTRICT_HEATING',
   ELECTRICITY = 'ELECTRICITY',
   COMMUNICATION = 'COMMUNICATION',

--- a/frontend/cypress/e2e/statistik-endast-elhandel.cy.ts
+++ b/frontend/cypress/e2e/statistik-endast-elhandel.cy.ts
@@ -7,14 +7,17 @@ import { Aggregation, Category } from '../../src/interfaces/measurement-data';
 import { getNetOwner } from '../fixtures/getNetOwner';
 import { getMyRelationsOnlyTrade } from '../fixtures/getMyRelations';
 import { getAgreementOnlyTrade } from '../fixtures/getMyPagedAgreements';
+import { isReady } from 'cypress/fixtures/ai';
 
 describe('Handle user with only trade agreement', () => {
   beforeEach(() => {
     cy.intercept('GET', '**/api/me', getMeOnlyTrade);
     interceptRepresentingMode(RepresentingMode.PRIVATE);
+    cy.intercept('GET', '**/api/paged/all-agreements', getAgreementOnlyTrade());
+    cy.intercept('GET', '**/api/ai/isReady', isReady(false));
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=ELECTRICITY&facilityId=111&fromDate=**&toDate=**&aggregateOn=DAY`,
+      `**/api/measurementdata?category=ELECTRICITY&facilityIds=111&fromDate=**&toDate=**&aggregateOn=DAY`,
       getStatisticsData(
         dayjs().startOf('month').format('YYYY-MM-DD'),
         dayjs().format('YYYY-MM-DD'),

--- a/frontend/cypress/e2e/statistik-previous-facility.cy.ts
+++ b/frontend/cypress/e2e/statistik-previous-facility.cy.ts
@@ -18,13 +18,13 @@ describe('Statistik - Handle previous (inactive) facility', () => {
 
     cy.intercept(
       'GET',
-      '**/api/measurementdata?category=ELECTRICITY&facilityId=444&fromDate=*&toDate=*&aggregateOn=*',
+      '**/api/measurementdata?category=ELECTRICITY&facilityIds=444&fromDate=*&toDate=*&aggregateOn=*',
       getStatisticsData(monthStart, today, Category.ELECTRICITY, Aggregation.DAY, '444')
     ).as('getPreviousFacilityData');
 
     cy.intercept(
       'GET',
-      '**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=DAY',
+      '**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=333&fromDate=*&toDate=*&aggregateOn=DAY',
       getStatisticsData(monthStart, today, Category.DISTRICT_HEATING, Aggregation.DAY)
     );
 

--- a/frontend/cypress/e2e/statistik-quarter.cy.ts
+++ b/frontend/cypress/e2e/statistik-quarter.cy.ts
@@ -19,7 +19,7 @@ describe('Statistik - QUARTER Aggregation', () => {
     const today = dayjs().format('YYYY-MM-DD');
     cy.intercept(
       'GET',
-      '**/api/measurementdata?category=DISTRICT_HEATING&facilityId=*&fromDate=*&toDate=*&aggregateOn=DAY',
+      '**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=*&fromDate=*&toDate=*&aggregateOn=DAY',
       getStatisticsData(monthStart, today, Category.DISTRICT_HEATING, Aggregation.DAY)
     );
 
@@ -27,19 +27,19 @@ describe('Statistik - QUARTER Aggregation', () => {
 
     cy.intercept(
       'GET',
-      '**/api/measurementdata?category=ELECTRICITY&facilityId=*&fromDate=*&toDate=*&aggregateOn=DAY',
+      '**/api/measurementdata?category=ELECTRICITY&facilityIds=*&fromDate=*&toDate=*&aggregateOn=DAY',
       getStatisticsData(monthStart, today, Category.ELECTRICITY, Aggregation.DAY)
     );
 
     cy.intercept(
       'GET',
-      '**/api/measurementdata?category=ELECTRICITY&facilityId=*&fromDate=*&toDate=*&aggregateOn=HOUR',
+      '**/api/measurementdata?category=ELECTRICITY&facilityIds=*&fromDate=*&toDate=*&aggregateOn=HOUR',
       getStatisticsData(today, today, Category.ELECTRICITY, Aggregation.HOUR)
     ).as('hourData');
 
     cy.intercept(
       'GET',
-      '**/api/measurementdata?category=ELECTRICITY&facilityId=*&fromDate=*&toDate=*&aggregateOn=QUARTER',
+      '**/api/measurementdata?category=ELECTRICITY&facilityIds=*&fromDate=*&toDate=*&aggregateOn=QUARTER',
       getStatisticsData(today, today, Category.ELECTRICITY, Aggregation.QUARTER)
     ).as('quarterData');
 

--- a/frontend/cypress/e2e/statistik.cy.ts
+++ b/frontend/cypress/e2e/statistik.cy.ts
@@ -7,16 +7,18 @@ import { Aggregation, Category } from '@interfaces/measurement-data';
 import { getNetOwner } from '../fixtures/getNetOwner';
 import path from 'path';
 import { createEvent, getEvents } from '../fixtures/getExportEvents';
+import { getMyPagedAgreements } from 'cypress/fixtures/getMyPagedAgreements';
 
 describe('Statistik', () => {
   beforeEach(() => {
     setIntercepts(RepresentingMode.PRIVATE);
+    cy.intercept('GET', '**/api/paged/all-agreements', getMyPagedAgreements());
   });
 
   const statisticsDataIntercept = () => {
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=**&toDate=**&aggregateOn=DAY`,
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=333&fromDate=**&toDate=**&aggregateOn=DAY`,
       getStatisticsData(
         dayjs().startOf('month').format('YYYY-MM-DD'),
         dayjs().format('YYYY-MM-DD'),
@@ -34,7 +36,7 @@ describe('Statistik', () => {
   const emptyStatisticsDataIntercept = () => {
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=DAY`,
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=333&fromDate=*&toDate=*&aggregateOn=DAY`,
       { fixture: null }
     );
 
@@ -88,12 +90,12 @@ describe('Statistik', () => {
 
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=DAY`,
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=333&fromDate=*&toDate=*&aggregateOn=DAY`,
       getStatisticsData(fromDate, toDate, Category.DISTRICT_HEATING, Aggregation.DAY)
     );
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=ELECTRICITY&facilityId=111&fromDate=*&toDate=*&aggregateOn=DAY`,
+      `**/api/measurementdata?category=ELECTRICITY&facilityIds=111&fromDate=*&toDate=*&aggregateOn=DAY`,
       getStatisticsData(fromDate, toDate, Category.ELECTRICITY, Aggregation.DAY)
     );
 
@@ -109,13 +111,13 @@ describe('Statistik', () => {
 
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=HOUR`,
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=333&fromDate=*&toDate=*&aggregateOn=HOUR`,
       getStatisticsData(fromDate, toDate, Category.DISTRICT_HEATING, Aggregation.HOUR)
     ).as('getStatisticsData');
 
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=MONTH`,
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=333&fromDate=*&toDate=*&aggregateOn=MONTH`,
       getStatisticsData(fromDate, toDate, Category.DISTRICT_HEATING, Aggregation.MONTH)
     ).as('getStatisticsData');
 
@@ -133,7 +135,7 @@ describe('Statistik', () => {
 
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=${fromDate}*&toDate=${toDate}*&aggregateOn=DAY`,
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=333&fromDate=${fromDate}*&toDate=${toDate}*&aggregateOn=DAY`,
       getStatisticsData(
         dayjs().startOf('month').subtract(1, 'year').format('YYYY-MM-DD'),
         dayjs().subtract(1, 'year').format('YYYY-MM-DD'),

--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -72,24 +72,24 @@ export const setIntercepts = (
 
   cy.intercept(
     'GET',
-    `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=MONTH`,
+    `**/api/measurementdata?category=DISTRICT_HEATING&facilityIds=333&fromDate=*&toDate=*&aggregateOn=MONTH`,
     getOverviewDistrictHeatingData(fromDate, toDate)
   ).as('getOverviewDistrictHeatingData');
 
   cy.intercept(
     'GET',
-    `**/api/measurementdata?category=ELECTRICITY&facilityId=111&fromDate=*&toDate=*&aggregateOn=MONTH`,
+    `**/api/measurementdata?category=ELECTRICITY&facilityIds=111&fromDate=*&toDate=*&aggregateOn=MONTH`,
     getOverviewElectricityData(fromDate, toDate)
   ).as('getOverviewElectricityData');
   cy.intercept(
     'GET',
-    `**/api/measurementdata?category=ELECTRICITY&facilityId=222&fromDate=*&toDate=*&aggregateOn=MONTH`,
+    `**/api/measurementdata?category=ELECTRICITY&facilityIds=222&fromDate=*&toDate=*&aggregateOn=MONTH`,
     getOverviewElectricityProductionData(fromDate, toDate)
   ).as('getOverviewElectricityProductionData');
 
   cy.intercept(
     'GET',
-    `**/api/measurementdata?category=ELECTRICITY&facilityId=444&fromDate=*&toDate=*&aggregateOn=MONTH`,
+    `**/api/measurementdata?category=ELECTRICITY&facilityIds=444&fromDate=*&toDate=*&aggregateOn=MONTH`,
     getOverviewElectricityData(fromDate, toDate)
   ).as('getOverviewPreviousFacilityData');
 };

--- a/frontend/src/data-contracts/backend/data-contracts.ts
+++ b/frontend/src/data-contracts/backend/data-contracts.ts
@@ -448,6 +448,21 @@ export interface PagedEventsResponse {
   empty?: boolean;
 }
 
+export interface BFUSApiResponse {
+  message: string;
+  data: any;
+}
+
+export interface BFUSEligablePartyApiResponse {
+  message: string;
+  data: any;
+}
+
+export interface BFUSNewPermissionApiResponse {
+  message: string;
+  data: boolean;
+}
+
 export interface PermissionHeaderDto {
   ExternalId: string;
   Operation: string;

--- a/frontend/src/interfaces/measurement-data.ts
+++ b/frontend/src/interfaces/measurement-data.ts
@@ -34,6 +34,7 @@ export interface Data {
 export interface MeasurementSerie {
   unit?: string;
   measurementType?: string;
+  facilityId?: string;
   metaData?: MetaData[];
   measurementPoints?: MeasurementPoints[];
 }

--- a/frontend/src/layouts/pages/mypages-sections/overview/consumption/consumption-card.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/overview/consumption/consumption-card.component.tsx
@@ -21,7 +21,7 @@ export const ConsumptionCard = (props: { facility: InstalledBaseItem; date: Dayj
     const lastDay = date.endOf('month').toISOString();
 
     params.append('category', getCategoryFromInstalledBaseType(facility.type));
-    params.append('facilityId', facility.facilityId ?? '');
+    params.append('facilityIds', facility.facilityId ?? '');
     params.append('fromDate', firstDay);
     params.append('toDate', lastDay);
     params.append('aggregateOn', 'MONTH');

--- a/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
@@ -92,7 +92,7 @@ export default function Charts() {
   ) => {
     const params = new URLSearchParams({
       category: categoryParam ?? '',
-      facilityId,
+      facilityIds: facilityId,
       fromDate,
       toDate,
       aggregateOn,

--- a/frontend/src/layouts/pages/mypages-sections/statistics/export-statistics-button/export-statistics.util.ts
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/export-statistics-button/export-statistics.util.ts
@@ -44,23 +44,30 @@ export const exportStatisticsToExcel = async ({ modalData, t }: ExportStatistics
   const excelMaxSheetName = 31;
   const workbook = utils.book_new();
 
-  for (const facility of modalData.selectedFacilities) {
-    const params = new URLSearchParams({
-      category: modalData.category,
-      facilityId: facility.facilityId,
-      fromDate: fromDateParam,
-      toDate: toDateParam,
-      aggregateOn: aggregation,
-    });
+  const params = new URLSearchParams();
+  params.append('category', modalData.category);
+  modalData.selectedFacilities.forEach((f) => params.append('facilityIds', f.facilityId));
+  params.append('fromDate', fromDateParam);
+  params.append('toDate', toDateParam);
+  params.append('aggregateOn', aggregation);
 
-    let facilityData: StatisticsMeasurementData | undefined;
-    try {
-      const response = await apiService.get<ApiResponse<Data>>(`/measurementdata?${params.toString()}`);
-      facilityData = statisticsMeasurementDataHandler(response.data.data);
-    } catch {
-      // If fetching data for a facility fails, we skip it and continue with the others. The export will still work for the facilities that were fetched successfully.
-      continue;
-    }
+  let data: Data | undefined;
+  try {
+    const response = await apiService.get<ApiResponse<Data>>(`/measurementdata?${params.toString()}`);
+    data = response.data.data;
+  } catch {
+    return false;
+  }
+
+  const dataForFacility = (facilityId: string): Data => ({
+    ...data,
+    measurementSeries: (data?.measurementSeries ?? []).filter((s) => s.facilityId === facilityId),
+  });
+
+  for (const facility of modalData.selectedFacilities) {
+    const facilityData: StatisticsMeasurementData = statisticsMeasurementDataHandler(
+      dataForFacility(facility.facilityId)
+    );
 
     const exportInformationHeadings = [
       [

--- a/frontend/src/layouts/pages/mypages-sections/statistics/export-statistics-button/export-statistics.util.ts
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/export-statistics-button/export-statistics.util.ts
@@ -53,7 +53,7 @@ export const exportStatisticsToExcel = async ({ modalData, t }: ExportStatistics
 
   let data: Data | undefined;
   try {
-    const response = await apiService.get<ApiResponse<Data>>(`/measurementdata?${params.toString()}`);
+    const response = await apiService.get<ApiResponse<Data>>(`/measurementdata?${params}`);
     data = response.data.data;
   } catch {
     return false;


### PR DESCRIPTION
# Pull Request

## Description

### Backend

- Bumped Measurementdata API to `3.3` (adds `MeasurementSerie.facilityId`) and regenerated contracts.
- `/measurementdata` now accepts a repeatable `facilityIds `param.

### Frontend

- Consumption card and statistics charts now send `facilityIds `instead of `facilityId`.
- Statistics export now fires one `/measurementdata` call for all selected facilities and splits the response per facility via `MeasurementSerie.facilityId`, instead of looping one request per facility.
- Cypress tests updated and stabilized;

## Background & Motivation
The statistics export fired N sequential /measurementdata calls (one per selected facility), which got slow for users with many facilities and put unnecessary load on WSO2. A previous attempt at batching was reverted because the API did not attribute measurement points back to a specific facility in the combined response. Measurementdata 3.3 fixes that by tagging each MeasurementSerie with its facilityId, so we can now batch safely and split the response client-side.

Related work item: [HYDRAN-1944](https://jira.sundsvall.se/browse/HYDRAN-1944).


## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
