### PR TITLE
Fix/hydran 1968 select day mode by default

### DIFF
--- a/frontend/cypress/e2e/statistik-endast-elhandel.cy.ts
+++ b/frontend/cypress/e2e/statistik-endast-elhandel.cy.ts
@@ -7,20 +7,19 @@ import { Aggregation, Category } from '../../src/interfaces/measurement-data';
 import { getNetOwner } from '../fixtures/getNetOwner';
 import { getMyRelationsOnlyTrade } from '../fixtures/getMyRelations';
 import { getAgreementOnlyTrade } from '../fixtures/getMyPagedAgreements';
+import { isReady } from 'cypress/fixtures/ai';
 
 describe('Handle user with only trade agreement', () => {
   beforeEach(() => {
     cy.intercept('GET', '**/api/me', getMeOnlyTrade);
     interceptRepresentingMode(RepresentingMode.PRIVATE);
+    cy.intercept('GET', '**/api/paged/all-agreements', getAgreementOnlyTrade());
+    cy.intercept('GET', '**/api/ai/isReady', isReady(false));
+    const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=ELECTRICITY&facilityId=111&fromDate=**&toDate=**&aggregateOn=DAY`,
-      getStatisticsData(
-        dayjs().startOf('month').format('YYYY-MM-DD'),
-        dayjs().format('YYYY-MM-DD'),
-        Category.ELECTRICITY,
-        Aggregation.DAY
-      )
+      `**/api/measurementdata?category=ELECTRICITY&facilityId=111&fromDate=**&toDate=**&aggregateOn=HOUR`,
+      getStatisticsData(yesterday, yesterday, Category.ELECTRICITY, Aggregation.HOUR)
     );
     cy.intercept('POST', '**/api/netowner', getNetOwner());
     cy.intercept('GET', '**/api/myrelations', getMyRelationsOnlyTrade);

--- a/frontend/cypress/e2e/statistik-previous-facility.cy.ts
+++ b/frontend/cypress/e2e/statistik-previous-facility.cy.ts
@@ -13,19 +13,18 @@ describe('Statistik - Handle previous (inactive) facility', () => {
   });
 
   const visitAndSelectPreviousFacility = () => {
-    const monthStart = dayjs().startOf('month').format('YYYY-MM-DD');
-    const today = dayjs().format('YYYY-MM-DD');
+    const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
 
     cy.intercept(
       'GET',
       '**/api/measurementdata?category=ELECTRICITY&facilityId=444&fromDate=*&toDate=*&aggregateOn=*',
-      getStatisticsData(monthStart, today, Category.ELECTRICITY, Aggregation.DAY, '444')
+      getStatisticsData(yesterday, yesterday, Category.ELECTRICITY, Aggregation.HOUR, '444')
     ).as('getPreviousFacilityData');
 
     cy.intercept(
       'GET',
-      '**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=DAY',
-      getStatisticsData(monthStart, today, Category.DISTRICT_HEATING, Aggregation.DAY)
+      '**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=HOUR',
+      getStatisticsData(yesterday, yesterday, Category.DISTRICT_HEATING, Aggregation.HOUR)
     );
 
     cy.intercept('POST', '**/api/netowner', getNetOwner());

--- a/frontend/cypress/e2e/statistik-quarter.cy.ts
+++ b/frontend/cypress/e2e/statistik-quarter.cy.ts
@@ -17,10 +17,11 @@ describe('Statistik - QUARTER Aggregation', () => {
   it('should render chart with QUARTER aggregation', () => {
     const monthStart = dayjs().startOf('month').format('YYYY-MM-DD');
     const today = dayjs().format('YYYY-MM-DD');
+    const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
     cy.intercept(
       'GET',
-      '**/api/measurementdata?category=DISTRICT_HEATING&facilityId=*&fromDate=*&toDate=*&aggregateOn=DAY',
-      getStatisticsData(monthStart, today, Category.DISTRICT_HEATING, Aggregation.DAY)
+      '**/api/measurementdata?category=DISTRICT_HEATING&facilityId=*&fromDate=*&toDate=*&aggregateOn=*',
+      getStatisticsData(yesterday, yesterday, Category.DISTRICT_HEATING, Aggregation.HOUR)
     );
 
     cy.intercept('POST', '**/api/netowner', getNetOwner());
@@ -34,13 +35,13 @@ describe('Statistik - QUARTER Aggregation', () => {
     cy.intercept(
       'GET',
       '**/api/measurementdata?category=ELECTRICITY&facilityId=*&fromDate=*&toDate=*&aggregateOn=HOUR',
-      getStatisticsData(today, today, Category.ELECTRICITY, Aggregation.HOUR)
+      getStatisticsData(yesterday, yesterday, Category.ELECTRICITY, Aggregation.HOUR)
     ).as('hourData');
 
     cy.intercept(
       'GET',
       '**/api/measurementdata?category=ELECTRICITY&facilityId=*&fromDate=*&toDate=*&aggregateOn=QUARTER',
-      getStatisticsData(today, today, Category.ELECTRICITY, Aggregation.QUARTER)
+      getStatisticsData(yesterday, yesterday, Category.ELECTRICITY, Aggregation.QUARTER)
     ).as('quarterData');
 
     cy.visit('/privat/statistik');
@@ -67,8 +68,8 @@ describe('Statistik - QUARTER Aggregation', () => {
 
     cy.get('[data-cy="average-consumption-value"]').should('exist').and('contain.text', '485');
 
-    // Verify day-select date picker is visible and set to today
-    cy.get('[data-cy="day-select"]').should('exist').and('have.value', monthStart);
+    // Verify day-select date picker is visible and defaults to yesterday
+    cy.get('[data-cy="day-select"]').should('exist').and('have.value', yesterday);
 
     // Verify TimeIntervalSelector: "15 min" is active (data-inverted="true"), "60 min" is not
     cy.contains('button', '15 min').should('have.attr', 'data-inverted', 'true');

--- a/frontend/cypress/e2e/statistik.cy.ts
+++ b/frontend/cypress/e2e/statistik.cy.ts
@@ -7,22 +7,20 @@ import { Aggregation, Category } from '@interfaces/measurement-data';
 import { getNetOwner } from '../fixtures/getNetOwner';
 import path from 'path';
 import { createEvent, getEvents } from '../fixtures/getExportEvents';
+import { getMyPagedAgreements } from 'cypress/fixtures/getMyPagedAgreements';
 
 describe('Statistik', () => {
   beforeEach(() => {
     setIntercepts(RepresentingMode.PRIVATE);
+    cy.intercept('GET', '**/api/paged/all-agreements', getMyPagedAgreements());
   });
 
   const statisticsDataIntercept = () => {
+    const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=**&toDate=**&aggregateOn=DAY`,
-      getStatisticsData(
-        dayjs().startOf('month').format('YYYY-MM-DD'),
-        dayjs().format('YYYY-MM-DD'),
-        Category.DISTRICT_HEATING,
-        Aggregation.DAY
-      )
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=**&toDate=**&aggregateOn=*`,
+      getStatisticsData(yesterday, yesterday, Category.DISTRICT_HEATING, Aggregation.HOUR)
     );
     cy.intercept('POST', '**/api/netowner', getNetOwner());
 
@@ -34,7 +32,7 @@ describe('Statistik', () => {
   const emptyStatisticsDataIntercept = () => {
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=DAY`,
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=*&toDate=*&aggregateOn=*`,
       { fixture: null }
     );
 
@@ -131,15 +129,11 @@ describe('Statistik', () => {
     const fromDate = dayjs().startOf('month').subtract(1, 'year').format('YYYY');
     const toDate = dayjs().subtract(1, 'year').format('YYYY');
 
+    const yesterdayLastYear = dayjs().subtract(1, 'day').subtract(1, 'year').format('YYYY-MM-DD');
     cy.intercept(
       'GET',
-      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=${fromDate}*&toDate=${toDate}*&aggregateOn=DAY`,
-      getStatisticsData(
-        dayjs().startOf('month').subtract(1, 'year').format('YYYY-MM-DD'),
-        dayjs().subtract(1, 'year').format('YYYY-MM-DD'),
-        Category.DISTRICT_HEATING,
-        Aggregation.DAY
-      )
+      `**/api/measurementdata?category=DISTRICT_HEATING&facilityId=333&fromDate=${fromDate}*&toDate=${toDate}*&aggregateOn=*`,
+      getStatisticsData(yesterdayLastYear, yesterdayLastYear, Category.DISTRICT_HEATING, Aggregation.HOUR)
     ).as('getStatisticsDataToCompare');
 
     cy.get('[data-cy="compare-year-select"]').should('exist').select(1);

--- a/frontend/cypress/fixtures/getMeasurementData.ts
+++ b/frontend/cypress/fixtures/getMeasurementData.ts
@@ -8,7 +8,7 @@ export const getOverviewDistrictHeatingData: (fromDate: string, toDate: string) 
 ) => ({
   data: {
     category: Category.DISTRICT_HEATING,
-    facilityId: '333',
+    facilityId: ['333'],
     aggregateOn: Aggregation.MONTH,
     toDate: toDate,
     fromDate: fromDate,
@@ -38,7 +38,7 @@ export const getOverviewElectricityData: (fromDate: string, toDate: string) => A
 ) => ({
   data: {
     category: Category.ELECTRICITY,
-    facilityId: '111',
+    facilityId: ['111'],
     aggregateOn: Aggregation.MONTH,
     toDate: toDate,
     fromDate: fromDate,
@@ -68,7 +68,7 @@ export const getOverviewElectricityProductionData: (fromDate: string, toDate: st
 ) => ({
   data: {
     category: Category.ELECTRICITY,
-    facilityId: '222',
+    facilityId: ['222'],
     aggregateOn: Aggregation.MONTH,
     toDate: toDate,
     fromDate: fromDate,
@@ -162,7 +162,7 @@ export const getStatisticsData: (
 ) => ApiResponse<Data> = (fromDate, toDate, category, aggregateOn, facilityId = '111') => ({
   data: {
     category: category,
-    facilityId: facilityId,
+    facilityId: [facilityId],
     aggregateOn: aggregateOn,
     toDate: toDate,
     fromDate: fromDate,

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-day.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-day.component.tsx
@@ -3,29 +3,23 @@
 import { StatisticsForm } from '@layouts/pages/mypages-sections/statistics.component';
 import { cx, DatePicker, FormLabel } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 export const StatisticsFilterDay: React.FC = () => {
-  const { setValue: setFormValue, watch } = useFormContext<StatisticsForm>();
-
+  const { setValue, watch } = useFormContext<StatisticsForm>();
   const { selectedYear, selectedMonth, selectedDay } = watch();
 
-  const [value, setValue] = useState<string>(
-    `${selectedYear ?? dayjs().format('YYYY')}-${selectedMonth ?? dayjs().format('MM')}-${selectedDay ?? dayjs().format('MM')}`
-  );
+  const date =
+    selectedYear && selectedMonth && selectedDay
+      ? `${selectedYear}-${selectedMonth}-${selectedDay}`
+      : dayjs().subtract(1, 'day').format('YYYY-MM-DD');
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newDate = dayjs(event.target.value);
-
-    const year = newDate.format('YYYY');
-    const month = newDate.format('MM');
-    const day = newDate.format('DD');
-
-    setFormValue('selectedYear', year);
-    setFormValue('selectedMonth', month);
-    setFormValue('selectedDay', day);
-    setValue(event.target.value);
+    setValue('selectedYear', newDate.format('YYYY'));
+    setValue('selectedMonth', newDate.format('MM'));
+    setValue('selectedDay', newDate.format('DD'));
   };
 
   return (
@@ -34,7 +28,7 @@ export const StatisticsFilterDay: React.FC = () => {
       <DatePicker
         className="w-full mt-8"
         type="date"
-        value={value}
+        value={date}
         min={dayjs().startOf('year').subtract(3, 'year').format('YYYY-MM-DD')}
         max={dayjs().format('YYYY-MM-DD')}
         name="day"

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-month.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-month.component.tsx
@@ -3,7 +3,7 @@
 import { StatisticsForm } from '@layouts/pages/mypages-sections/statistics.component';
 import { cx, FormLabel, Select } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
-import { ChangeEvent, useMemo, useState } from 'react';
+import { ChangeEvent, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { generateSelectableMonths } from '../generateDateLists';
 
@@ -12,29 +12,24 @@ export const StatisticsFilterMonth: React.FC = () => {
     return generateSelectableMonths(dayjs().format('YYYY-MM-DD'));
   }, []);
 
-  const { setValue: setFormValue, watch } = useFormContext<StatisticsForm>();
-
+  const { setValue, watch } = useFormContext<StatisticsForm>();
   const { selectedYear, selectedMonth } = watch();
 
-  const [value, setValue] = useState<string>(
-    `${selectedYear ?? dayjs().format('YYYY')}-${selectedMonth ?? dayjs().format('MM')}-01`
-  );
+  const date =
+    selectedYear && selectedMonth
+      ? `${selectedYear}-${selectedMonth}-01`
+      : dayjs().subtract(1, 'day').startOf('month').format('YYYY-MM-DD');
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const newDate = dayjs(event.target.value);
-
-    const year = newDate.format('YYYY');
-    const month = newDate.format('MM');
-
-    setFormValue('selectedYear', year);
-    setFormValue('selectedMonth', month);
-    setValue(event.target.value);
+    setValue('selectedYear', newDate.format('YYYY'));
+    setValue('selectedMonth', newDate.format('MM'));
   };
 
   return (
     <div className={cx(`w-full lg:pt-0 pt-16`)}>
       <FormLabel>Månad</FormLabel>
-      <Select className="w-full mt-8" value={value} name="month" onChange={handleChange} data-cy="month-select">
+      <Select className="w-full mt-8" value={date} name="month" onChange={handleChange} data-cy="month-select">
         {selectableMonths.map((dateObj) => (
           <Select.Option key={dateObj.value} value={dateObj.value}>
             {dateObj.label}

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-year.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/components/statistics-filter-year.component.tsx
@@ -3,7 +3,7 @@
 import { StatisticsForm } from '@layouts/pages/mypages-sections/statistics.component';
 import { cx, FormLabel, Select } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
-import { ChangeEvent, useMemo, useState } from 'react';
+import { ChangeEvent, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { generateSelectableYears } from '../generateDateLists';
 
@@ -12,24 +12,20 @@ export const StatisticsFilterYear: React.FC = () => {
     return generateSelectableYears(dayjs().format('YYYY-MM-DD'));
   }, []);
 
-  const { setValue: setFormValue, watch } = useFormContext<StatisticsForm>();
+  const { setValue, watch } = useFormContext<StatisticsForm>();
+  const { selectedYear } = watch();
 
-  const { selectedYear, selectedMonth, selectedDay } = watch();
-
-  const [value, setValue] = useState<string>(`${selectedYear}-01-01`);
+  const date = selectedYear ? `${selectedYear}-01-01` : dayjs().subtract(1, 'day').startOf('year').format('YYYY-MM-DD');
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const dateArr = event.target.value.split('-');
-    const newDate = dayjs(`${dateArr[0]}-${selectedMonth}-${selectedDay}`);
-    const year = newDate.format('YYYY');
-    setFormValue('selectedYear', year);
-    setValue(event.target.value);
+    const [year] = event.target.value.split('-');
+    setValue('selectedYear', year);
   };
 
   return (
     <div className={cx(`w-full lg:pt-0 pt-16`)}>
       <FormLabel>År</FormLabel>
-      <Select value={value} name="year" className="w-full mt-8" onChange={handleChange} data-cy="year-select">
+      <Select value={date} name="year" className="w-full mt-8" onChange={handleChange} data-cy="year-select">
         {selectableYears.map((dateString) => (
           <Select.Option key={`selectedYear-${dateString}`} value={dateString}>
             {dayjs(dateString).format('YYYY')}

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
@@ -5,7 +5,7 @@ import { User } from '@interfaces/user';
 import { generateComparableYears } from '@layouts/pages/mypages-sections/statistics/statistics-filter/generateDateLists';
 import { useApi } from '@services/api-service';
 import { Button, FormLabel, NavigationBar, Select } from '@sk-web-gui/react';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -27,7 +27,7 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
   const { closeHandler } = props;
   const { register, watch, setValue } = useFormContext<StatisticsForm>();
   const [facilities, setFacilities] = useState<InstalledBaseItem[]>();
-  const [mode, setMode] = useState<'day' | 'month' | 'year'>('month');
+  const [mode, setMode] = useState<'day' | 'month' | 'year'>('day');
   const { address, fromDate, selectedDay, selectedMonth, selectedYear, isHourQuarter } = watch();
 
   const { data: user } = useApi<User>({
@@ -96,24 +96,22 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
   }, [mode, setValue]);
 
   useEffect(() => {
-    const setDate = (by: 'year' | 'month' | 'day', _date?: Dayjs) => {
-      const y = selectedYear ?? dayjs().format('YYYY');
-      const m = selectedMonth ?? dayjs().format('MM');
-      const d = selectedDay ?? dayjs().format('DD');
-      const date = _date ?? dayjs(`${y}-${m}-${by === 'day' ? d : '01'}`);
-      const fromDate = date.startOf(by).format('YYYY-MM-DD');
-      const toDate = date.endOf(by).format('YYYY-MM-DD');
-      const year = date.format('YYYY');
-      const month = date.format('MM');
-      const day = date.format('DD');
-      setValue('fromDate', fromDate);
-      setValue('toDate', toDate);
-      setValue('selectedYear', year);
-      setValue('selectedMonth', month);
-      setValue('selectedDay', day);
-    };
+    const yesterday = dayjs().subtract(1, 'day');
+    const y = selectedYear ?? yesterday.format('YYYY');
+    const m = selectedMonth ?? yesterday.format('MM');
+    const d = selectedDay ?? yesterday.format('DD');
+    const date = dayjs(`${y}-${m}-${mode === 'day' ? d : '01'}`);
 
-    setDate(mode);
+    setValue('fromDate', date.startOf(mode).format('YYYY-MM-DD'));
+    setValue('toDate', date.endOf(mode).format('YYYY-MM-DD'));
+
+    setValue('selectedYear', date.format('YYYY'));
+    if (mode === 'month' || mode === 'day') {
+      setValue('selectedMonth', date.format('MM'));
+    }
+    if (mode === 'day') {
+      setValue('selectedDay', date.format('DD'));
+    }
   }, [mode, selectedDay, selectedMonth, selectedYear, setValue]);
 
   return (


### PR DESCRIPTION
# Pull Request

## Description

### Summary

Fixes [HYDRAN-1968](https://jira.sundsvall.se/browse/HYDRAN-1968). Two user-visible issues in the statistics filter:

- First-time visitors to the statistics page landed on the 1st of the current month in day view. They now land on **yesterday**, per product request.
- Selecting a specific day (e.g. April 8th), switching to Månad, then back to Dag reset the selection to the 1st of the month. The chosen day is now **preserved** across mode toggles.

### Commits

1. `fix: default to yesterday and preserve day across mode toggles` — the actual fix. The mode-switch effect no longer clobbers `selectedDay`/`selectedMonth` when switching to a coarser granularity, and the fallback derives all three date parts from a single "yesterday" dayjs (avoiding month-boundary weirdness like `2026-04-31`).
2. `refactor: use form as single source of truth for date filter` — removes redundant `useState` + `useEffect` mirrors in the day/month/year sub-components; display value is now derived directly from form state.
3. `chore: stabilize cypress tests` — Cypress fixtures/intercepts aligned with the new defaults: initial load is now `aggregateOn=HOUR` for yesterday (day mode) rather than `DAY` for a month range, and the quarter spec's `day-select` assertion now checks yesterday instead of the 1st of the month (which was accidentally asserting the old bug). Also fixes a pre-existing `Data.facilityId: string[]` mismatch in `getMeasurementData.ts` that the IDE surfaced while editing.

### Test Plan

- [ ] Visit `/privat/statistik` as a fresh user → Dag selector shows **yesterday**
- [ ] Pick April 8 in Dag → switch to Månad → switch back to Dag → Dag selector still shows **April 8**
- [ ] Pick a month in Månad → switch to År → switch back to Månad → month selection preserved
- [ ] On the 1st of a month: first load should show yesterday (last day of previous month), not an invalid date

## Background & Motivation

Bug Report: [HYDRAN-1968](https://jira.sundsvall.se/browse/HYDRAN-1968) 

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
