### PR TITLE
fix: preserve local timezone offset in measurementdata date params

### DIFF
--- a/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
@@ -63,22 +63,20 @@ export default function Charts() {
   }, [fromDate, toDate, isHourQuarter, categoryParam]);
 
   const fromDateParam = useMemo(() => {
-    return dayjs(fromDate).startOf('date').utc(true).format();
+    return dayjs(fromDate).startOf('date').format();
   }, [fromDate]);
   const toDateParam = useMemo(() => {
-    return dayjs(toDate).endOf('date').utc(true).format();
+    return dayjs(toDate).endOf('date').format();
   }, [toDate]);
   const fromDatePreviousParam = useMemo(() => {
     return dayjs(fromDate)
       .subtract(parseInt(dayjs(fromDate).format('YYYY')) - year, 'year')
-      .utc(true)
       .startOf('date')
       .format();
   }, [fromDate, year]);
   const toDatePreviousParam = useMemo(() => {
     return dayjs(toDate)
       .subtract(parseInt(dayjs(toDate).format('YYYY')) - year, 'year')
-      .utc(true)
       .endOf('date')
       .format();
   }, [toDate, year]);

--- a/frontend/src/layouts/pages/mypages-sections/statistics/export-statistics-button/export-statistics.util.ts
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/export-statistics-button/export-statistics.util.ts
@@ -25,8 +25,8 @@ export const buildLogInformation = (modalData: ExportModalData): CreateLogEventD
   return modalData.selectedFacilities.map((f) => ({
     facilityId: f.facilityId,
     facilityAddress: f.address,
-    fromDate: dayjs(modalData.fromDate).utc(true).toISOString(),
-    toDate: dayjs(modalData.toDate).utc(true).toISOString(),
+    fromDate: dayjs(modalData.fromDate).format(),
+    toDate: dayjs(modalData.toDate).format(),
     category: getEventCategory(modalData.category),
     aggregation,
   }));
@@ -34,13 +34,13 @@ export const buildLogInformation = (modalData: ExportModalData): CreateLogEventD
 
 export const exportStatisticsToExcel = async ({ modalData, t }: ExportStatisticsOptions): Promise<boolean> => {
   const aggregation = modalData.timeResolution.toUpperCase() as Aggregation;
-  const fromDateParam = dayjs(modalData.fromDate).startOf('date').utc(true).format();
+  const fromDateParam = dayjs(modalData.fromDate).startOf('date').format();
   const toDateEndOfByAggregation: Partial<Record<Aggregation, OpUnitType>> = {
     [Aggregation.MONTH]: 'year',
     [Aggregation.DAY]: 'month',
   };
   const toDateEndOf: OpUnitType = toDateEndOfByAggregation[aggregation] ?? 'date';
-  const toDateParam = dayjs(modalData.toDate).endOf(toDateEndOf).utc(true).format();
+  const toDateParam = dayjs(modalData.toDate).endOf(toDateEndOf).format();
   const excelMaxSheetName = 31;
   const workbook = utils.book_new();
 


### PR DESCRIPTION
# Pull Request

## Description

The `MeasurementData` API requires request timestamps to include an explicit timezone offset; without one, periods bleed into the next day.

The frontend was emitting UTC-labeled timestamps via `dayjs(...).utc(true)`, which keeps the wall-clock digits and relabels them as `Z`. For a November selection in Swedish time, `2025-11-30T23:59:59Z` was interpreted server-side as local time and rolled into December.

**Fix:** drop `.utc(true)` / `.toISOString()` so dayjs formats with the local offset (e.g. `2025-11-30T23:59:59+01:00`).

**Scope:** statistics chart and Excel export. 

**Verify**
- Pick a month in Statistics → last data point is the last day, not the 1st of the next month.
- Export that month → final Excel row matches.
- Event log entries from the export show `+01:00`/`+02:00` instead of `Z`.


## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-2031

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
