### PR TITLE
fix: use representing party id

### DIFF
--- a/backend/src/controllers/disturbances.controller.ts
+++ b/backend/src/controllers/disturbances.controller.ts
@@ -9,6 +9,7 @@ import { Controller, Get, Req, UseBefore } from 'routing-controllers';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 import { Disturbance } from '@/data-contracts/disturbances/data-contracts';
 import { DisturbanceApiResponse } from '@/responses/disturbances.response';
+import { getRepresentingPartyId } from '@utils/getRepresentingPartyId';
 
 @Controller()
 export class DisturbancesController {
@@ -21,14 +22,15 @@ export class DisturbancesController {
   @UseBefore(authMiddleware)
   @ResponseSchema(DisturbanceApiResponse)
   async getDisturbances(@Req() req: RequestWithUser): Promise<ApiResponse<Disturbance[]>> {
-    const userPartyId = req.user.partyId;
-    if (!userPartyId) {
+    const representing = req.session?.representing ?? undefined;
+    const partyId = getRepresentingPartyId(representing);
+    if (!partyId) {
       throw new HttpException(400, 'Bad request, missing partyId');
     }
 
     const delegations = req?.session?.cache?.delegations ?? [];
     const delegationPartyIds: string[] = delegations.map(d => d.owner);
-    const partyIdList = [userPartyId, ...delegationPartyIds];
+    const partyIdList = [partyId, ...delegationPartyIds];
 
     const { status } = req.query;
 


### PR DESCRIPTION
# Pull Request

## Description

Use representing partyId instead of user session partyId. 

## Background & Motivation

When switching between Person and Organisation, disturbance data should change since it is based on facilities and addresses connected to current (representing) partyId.

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
