### PR TITLE
fix: use post instead of get for citizen search

### DIFF
--- a/backend/src/controllers/citizen.controller.ts
+++ b/backend/src/controllers/citizen.controller.ts
@@ -8,8 +8,15 @@ import { CitizenApiResponse } from '@/responses/citizen.response';
 import ApiService from '@/services/api.service';
 import { logger } from '@/utils/logger';
 import { Response } from 'express';
-import { Controller, Get, Param, Req, Res, UseBefore } from 'routing-controllers';
+import { Body, Controller, Post, Req, Res, UseBefore } from 'routing-controllers';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
+import { IsString, Length } from 'class-validator';
+
+class CitizenLookupDto {
+  @IsString()
+  @Length(12, 12)
+  personnumber: string;
+}
 
 @Controller()
 export class CitizenController {
@@ -17,17 +24,17 @@ export class CitizenController {
   private readonly apiBase = getApiBase('citizen');
   private readonly baseUrl = `${this.apiBase}/${MUNICIPALITY_ID}`;
 
-  @Get('/citizen/:personnumber')
+  @Post('/citizen')
   @OpenAPI({ summary: 'Return a citizen' })
   @UseBefore(authMiddleware)
   @ResponseSchema(CitizenApiResponse)
   async getCitizen(
     @Req() req: RequestWithUser,
-    @Param('personnumber') personnumber: string,
+    @Body() body: CitizenLookupDto,
     @Res() res: Response<CitizenApiResponse>,
   ): Promise<Response<CitizenApiResponse>> {
     const { user } = req;
-    const guidUrl = `${this.baseUrl}/${personnumber}/guid`;
+    const guidUrl = `${this.baseUrl}/${body.personnumber}/guid`;
     try {
       const guid = await this.apiService.get<string>({ url: guidUrl }, user);
       if (!guid) {

--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -59,7 +59,7 @@ export const setIntercepts = (
   cy.intercept('GET', '**/api/delegates', getDelegates()).as('getDelegates');
   cy.intercept('GET', '**/api/facility/delegations', getFacilityDelegates()).as('getFacilityDelegates');
 
-  cy.intercept('GET', '**/api/citizen/**', getCitizen).as('getCitizen');
+  cy.intercept('POST', '**/api/citizen', getCitizen).as('getCitizen');
   cy.intercept('GET', '**/api/mandates/org', getOrgMandates).as('getOrgMandates');
   cy.intercept('GET', '**/api/ai/isReady', isReady()).as('AIisReady');
 

--- a/frontend/src/services/citizen-service.ts
+++ b/frontend/src/services/citizen-service.ts
@@ -5,7 +5,7 @@ import { useSnackbar } from '@sk-web-gui/react';
 import { useTranslation } from 'react-i18next';
 
 const getCitizen = (personnumber: string) => {
-  return apiService.get<CitizenApiResponse>(`/citizen/${personnumber}`);
+  return apiService.post<CitizenApiResponse>('/citizen', { personnumber });
 };
 
 export const useCitizen = (personnumber?: string) => {


### PR DESCRIPTION
Byter GET till POST på medborgarsök när en ny fullmakt ska skapas. Med GET-anropet skickas personnummer i urlen vilket gör att det kan loggas på diverse ställen. Postanropet undviker denna risk.

# Pull Request

## Description

Briefly describe what was changed and why (for both frontend and backend if relevant).

## Background & Motivation

Why was this change needed? Describe any related issues if applicable.

If applicable, link the related work item (Jira story/issue, Azure DevOps work item, GitLab issue, GitHub issue..)

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [ ] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
