### PR TITLE
fix: handles page render for agreements pagination (HYDRAN-1864)

### DIFF
--- a/frontend/src/layouts/pages/mypages-sections/agreements.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/agreements.component.tsx
@@ -2,7 +2,7 @@
 
 import { Pagination, SearchField, Select, Spinner } from '@sk-web-gui/react';
 import { AgreementListItem } from '@layouts/pages/mypages-sections/agreements/agreement-list-item/agreement-list-item.component';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useApi } from '@services/api-service';
 import { getCategoryAsNumber, pagedAgreementsWithMetaHandler } from '@services/agreement-service';
 import { AgreementData, RefinedAgreement } from '@interfaces/agreement';
@@ -10,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 
 export default function PagedAgreements() {
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [pages, setPages] = useState<number>(1);
   const [limit, setLimit] = useState<number>(20);
 
   const {
@@ -26,14 +25,10 @@ export default function PagedAgreements() {
   });
 
   const agreements = response?.agreements;
-  const meta = response?._meta;
+  const pages = response?._meta?.totalPages ?? 1;
 
   const [term, setTerm] = useState<string>('');
   const { t } = useTranslation(['common', 'agreement']);
-
-  useEffect(() => {
-    setPages(meta?.totalPages ?? 1);
-  }, [meta]);
 
   const data = useMemo<AgreementData | undefined>(() => {
     if (!agreements) return undefined;


### PR DESCRIPTION
# Pull Request

## Description

- Tog bort useState för pages och useEffect'en som hanterade state't
- Kollar pages direkt: `const pages = response?._meta?.totalPages ?? 1;`

## General Checklist

- [ ] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [ ] Project builds locally without errors
- [ ] ESLint/Prettier have been run and are OK
- [ ] API changes are documented (OpenAPI/README)
- [ ] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [ ] All affected pages render correctly (SSR/CSR)
- [ ] Navigation works
- [ ] API calls from the frontend continue to work
- [ ] Any forms/flows function correctly
- [ ] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [ ] Affected endpoints behave as expected
- [ ] No changes break existing contracts
- [ ] Error handling works correctly
- [ ] Logging behaves normally
- [ ] Protected endpoints validated (auth/session/JWT)
