### PR TITLE
Feature/hydran 1865 batch agreements in statistics

### DIFF
--- a/backend/src/controllers/agreement.controller.ts
+++ b/backend/src/controllers/agreement.controller.ts
@@ -51,6 +51,34 @@ export class AgreementController {
     return { data, message: 'success' };
   }
 
+  private async handleAgreementsRequest(
+    req: RequestWithUser,
+    page: number | undefined,
+    limit: number | undefined,
+    includeInactive: boolean,
+  ): Promise<ApiResponse<Agreement[] | PagedAgreementsResult>> {
+    if (page === undefined) {
+      return this.fetchAgreements(req, includeInactive);
+    }
+
+    const { partyId, partyIdList, delegations } = this.getSessionData(req);
+    if (!partyId) {
+      throw new HttpException(400, 'No partyId found');
+    }
+
+    const data = await fetchPagedAgreements(
+      partyId,
+      partyIdList,
+      delegations,
+      req.user,
+      page,
+      limit ?? 100,
+      relevantCategories,
+      includeInactive,
+    );
+    return { data, message: 'success' };
+  }
+
   @Get('/paged/agreements')
   @OpenAPI({ summary: 'Get agreements by party id' })
   @UseBefore(authMiddleware)
@@ -59,33 +87,18 @@ export class AgreementController {
     @QueryParam('page') page?: number,
     @QueryParam('limit') limit?: number,
   ): Promise<ApiResponse<Agreement[] | PagedAgreementsResult>> {
-    if (page !== undefined) {
-      const { partyId, partyIdList, delegations } = this.getSessionData(req);
-
-      if (!partyId) {
-        throw new HttpException(400, 'No partyId found');
-      }
-
-      const data = await fetchPagedAgreements(
-        partyId,
-        partyIdList,
-        delegations,
-        req.user,
-        page,
-        limit ?? 100,
-        relevantCategories,
-      );
-      return { data, message: 'success' };
-    }
-
-    return this.fetchAgreements(req, false);
+    return this.handleAgreementsRequest(req, page, limit, false);
   }
 
   @Get('/paged/all-agreements')
   @OpenAPI({ summary: 'Get all agreements (active and inactive) by party id' })
   @UseBefore(authMiddleware)
-  async getAllAgreements(@Req() req: RequestWithUser): Promise<ApiResponse<Agreement[]>> {
-    return this.fetchAgreements(req, true);
+  async getAllAgreements(
+    @Req() req: RequestWithUser,
+    @QueryParam('page') page?: number,
+    @QueryParam('limit') limit?: number,
+  ): Promise<ApiResponse<Agreement[] | PagedAgreementsResult>> {
+    return this.handleAgreementsRequest(req, page, limit, true);
   }
 
   @Get('/agreement/:category/:facilityId')

--- a/backend/src/services/agreement.service.ts
+++ b/backend/src/services/agreement.service.ts
@@ -93,6 +93,7 @@ export const fetchPagedAgreements = async (
   page: number,
   limit: number,
   categories: Category[] = [],
+  includeInactive: boolean = false,
 ): Promise<PagedAgreementsResult> => {
   const apiService = new ApiService();
   const apiBase = getApiBase('agreement');
@@ -107,7 +108,10 @@ export const fetchPagedAgreements = async (
     user,
   );
 
-  let agreements = (res.data.agreements ?? []).filter(activeAgreement).filter(a => a.mainAgreement === true);
+  let agreements = res.data.agreements ?? [];
+  if (!includeInactive) {
+    agreements = agreements.filter(activeAgreement).filter(a => a.mainAgreement === true);
+  }
 
   if (page === 1) {
     const delegationAgreements: Agreement[] = [];
@@ -115,14 +119,15 @@ export const fetchPagedAgreements = async (
     for (const delegationPartyId of partyIdList) {
       const delegationUrl = `${apiBase}/${MUNICIPALITY_ID}/paged/agreements/${delegationPartyId}`;
       const allDelegationAgreements = await fetchAllAgreementPages(apiService, delegationUrl, user, categories);
-      delegationAgreements.push(...allDelegationAgreements.filter(activeAgreement));
+      const filteredDelegations = includeInactive
+        ? allDelegationAgreements
+        : allDelegationAgreements.filter(activeAgreement).filter(a => a.mainAgreement === true);
+      delegationAgreements.push(...filteredDelegations);
     }
 
-    const matchedDelegationAgreements = delegationAgreements
-      .filter(agreement =>
-        delegations.some(delegation => delegation.facilities.some(facility => facility.id === agreement.facilityId)),
-      )
-      .filter(a => a.mainAgreement === true);
+    const matchedDelegationAgreements = delegationAgreements.filter(agreement =>
+      delegations.some(delegation => delegation.facilities.some(facility => facility.id === agreement.facilityId)),
+    );
 
     agreements = [...agreements, ...matchedDelegationAgreements];
   }

--- a/frontend/cypress/e2e/statistik-endast-elhandel.cy.ts
+++ b/frontend/cypress/e2e/statistik-endast-elhandel.cy.ts
@@ -13,7 +13,13 @@ describe('Handle user with only trade agreement', () => {
   beforeEach(() => {
     cy.intercept('GET', '**/api/me', getMeOnlyTrade);
     interceptRepresentingMode(RepresentingMode.PRIVATE);
-    cy.intercept('GET', '**/api/paged/all-agreements', getAgreementOnlyTrade());
+    cy.intercept('GET', '**/api/paged/all-agreements?page=*', {
+      data: {
+        agreements: getAgreementOnlyTrade().data,
+        _meta: { page: 1, limit: 100, totalPages: 1 },
+      },
+      message: 'success',
+    });
     cy.intercept('GET', '**/api/ai/isReady', isReady(false));
     const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
     cy.intercept(

--- a/frontend/cypress/e2e/statistik-previous-facility.cy.ts
+++ b/frontend/cypress/e2e/statistik-previous-facility.cy.ts
@@ -4,12 +4,10 @@ import { getStatisticsData } from '../fixtures/getMeasurementData';
 import dayjs from 'dayjs';
 import { Aggregation, Category } from '@interfaces/measurement-data';
 import { getNetOwner } from '../fixtures/getNetOwner';
-import { getMyPagedAgreements } from '../fixtures/getMyPagedAgreements';
 
 describe('Statistik - Handle previous (inactive) facility', () => {
   beforeEach(() => {
     setIntercepts(RepresentingMode.PRIVATE);
-    cy.intercept('GET', '**/api/paged/all-agreements', getMyPagedAgreements()).as('getAllAgreements');
   });
 
   const visitAndSelectPreviousFacility = () => {

--- a/frontend/cypress/e2e/statistik-quarter.cy.ts
+++ b/frontend/cypress/e2e/statistik-quarter.cy.ts
@@ -4,14 +4,12 @@ import { getStatisticsData } from '../fixtures/getMeasurementData';
 import dayjs from 'dayjs';
 import { Aggregation, Category } from '@interfaces/measurement-data';
 import { getNetOwner } from '../fixtures/getNetOwner';
-import { getMyPagedAgreements } from '../fixtures/getMyPagedAgreements';
 import { isReady } from '../fixtures/ai';
 
 describe('Statistik - QUARTER Aggregation', () => {
   beforeEach(() => {
     setIntercepts(RepresentingMode.PRIVATE);
     cy.intercept('GET', '**/api/ai/isReady', isReady(false)).as('AIisReady');
-    cy.intercept('GET', '**/api/paged/all-agreements', getMyPagedAgreements());
   });
 
   it('should render chart with QUARTER aggregation', () => {

--- a/frontend/cypress/e2e/statistik.cy.ts
+++ b/frontend/cypress/e2e/statistik.cy.ts
@@ -7,12 +7,9 @@ import { Aggregation, Category } from '@interfaces/measurement-data';
 import { getNetOwner } from '../fixtures/getNetOwner';
 import path from 'path';
 import { createEvent, getEvents } from '../fixtures/getExportEvents';
-import { getMyPagedAgreements } from 'cypress/fixtures/getMyPagedAgreements';
-
 describe('Statistik', () => {
   beforeEach(() => {
     setIntercepts(RepresentingMode.PRIVATE);
-    cy.intercept('GET', '**/api/paged/all-agreements', getMyPagedAgreements());
   });
 
   const statisticsDataIntercept = () => {

--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -54,6 +54,13 @@ export const setIntercepts = (
     },
     message: 'success',
   }).as('getMyPagedAgreementsPages');
+  cy.intercept('GET', '**/api/paged/all-agreements?page=*', {
+    data: {
+      agreements: getMyPagedAgreements().data,
+      _meta: { page: 1, limit: 100, totalPages: 1 },
+    },
+    message: 'success',
+  }).as('getMyPagedAllAgreementsPages');
   cy.intercept('GET', '**/api/contactsettings', getContactSettings(representingMode)).as('getContactSettings');
 
   cy.intercept('GET', '**/api/delegates', getDelegates()).as('getDelegates');

--- a/frontend/locales/sv/statistics.json
+++ b/frontend/locales/sv/statistics.json
@@ -1,6 +1,7 @@
 {
   "title": "Din statistik",
   "filter": "Filter",
+  "label": "Filtrera",
   "agreementType": "Avtalstyp",
   "showBy": "Visa statistik per",
   "exportBy": "Exportera statistik per",

--- a/frontend/src/layouts/pages/mypages-sections/statistics.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics.component.tsx
@@ -45,12 +45,7 @@ export default function Statistics() {
     queryKey: ['user'],
   });
 
-  const {
-    agreements: allAgreements,
-    isDone: isAllAgreementsDone,
-    currentPage: allAgreementsCurrentPage,
-    totalPages: allAgreementsTotalPages,
-  } = usePagedAgreements(200, true);
+  const { agreements: allAgreements, isDone, currentPage, totalPages } = usePagedAgreements(200, true);
 
   const openHandler = () => {
     setIsOpen(true);
@@ -59,6 +54,10 @@ export default function Statistics() {
   const closeHandler = () => {
     setIsOpen(false);
   };
+
+  const statisticsFilter = (
+    <StatisticsFilter closeHandler={closeHandler} allAgreements={{ isDone, currentPage, totalPages }} />
+  );
 
   return (
     <div>
@@ -75,16 +74,8 @@ export default function Statistics() {
             <Spinner className="mx-auto" />
           ) : (
             <>
-              <div className="sm:block hidden">
-                <StatisticsFilter
-                  closeHandler={closeHandler}
-                  isAllAgreementsDone={isAllAgreementsDone}
-                  allAgreementsCurrentPage={allAgreementsCurrentPage}
-                  allAgreementsTotalPages={allAgreementsTotalPages}
-                />
-              </div>
-
-              <Charts allAgreements={allAgreements} isAllAgreementsDone={isAllAgreementsDone} />
+              <div className="sm:block hidden">{statisticsFilter}</div>
+              <Charts allAgreements={allAgreements} isAllAgreementsDone={isDone} />
             </>
           )}
         </form>
@@ -94,16 +85,9 @@ export default function Statistics() {
           disableCloseOutside={true}
           show={isOpen}
           onClose={closeHandler}
-          label="Filtrera"
+          label={t('statistics:label')}
         >
-          <Modal.Content>
-            <StatisticsFilter
-              closeHandler={closeHandler}
-              isAllAgreementsDone={isAllAgreementsDone}
-              allAgreementsCurrentPage={allAgreementsCurrentPage}
-              allAgreementsTotalPages={allAgreementsTotalPages}
-            />
-          </Modal.Content>
+          <Modal.Content>{statisticsFilter}</Modal.Content>
         </Modal>
       </FormProvider>
 

--- a/frontend/src/layouts/pages/mypages-sections/statistics.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics.component.tsx
@@ -9,6 +9,7 @@ import { useApi } from '@services/api-service';
 import { User } from '@interfaces/user';
 import { Button, Modal, Spinner } from '@sk-web-gui/react';
 import { useTranslation } from 'react-i18next';
+import { usePagedAgreements } from '@utils/use-paged-agreements.hook';
 
 export interface StatisticsForm {
   category: string;
@@ -44,6 +45,13 @@ export default function Statistics() {
     queryKey: ['user'],
   });
 
+  const {
+    agreements: allAgreements,
+    isDone: isAllAgreementsDone,
+    currentPage: allAgreementsCurrentPage,
+    totalPages: allAgreementsTotalPages,
+  } = usePagedAgreements(200, true);
+
   const openHandler = () => {
     setIsOpen(true);
   };
@@ -68,10 +76,15 @@ export default function Statistics() {
           ) : (
             <>
               <div className="sm:block hidden">
-                <StatisticsFilter closeHandler={closeHandler} />
+                <StatisticsFilter
+                  closeHandler={closeHandler}
+                  isAllAgreementsDone={isAllAgreementsDone}
+                  allAgreementsCurrentPage={allAgreementsCurrentPage}
+                  allAgreementsTotalPages={allAgreementsTotalPages}
+                />
               </div>
 
-              <Charts />
+              <Charts allAgreements={allAgreements} isAllAgreementsDone={isAllAgreementsDone} />
             </>
           )}
         </form>
@@ -84,7 +97,12 @@ export default function Statistics() {
           label="Filtrera"
         >
           <Modal.Content>
-            <StatisticsFilter closeHandler={closeHandler} />
+            <StatisticsFilter
+              closeHandler={closeHandler}
+              isAllAgreementsDone={isAllAgreementsDone}
+              allAgreementsCurrentPage={allAgreementsCurrentPage}
+              allAgreementsTotalPages={allAgreementsTotalPages}
+            />
           </Modal.Content>
         </Modal>
       </FormProvider>

--- a/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
@@ -23,8 +23,8 @@ import { useTranslation } from 'react-i18next';
 import { getCategoryFromInstalledBaseType } from '@utils/facility';
 
 export interface ChartsProps {
-  allAgreements: AgreementData;
-  isAllAgreementsDone: boolean;
+  readonly allAgreements: AgreementData;
+  readonly isAllAgreementsDone: boolean;
 }
 
 export default function Charts({ allAgreements, isAllAgreementsDone }: ChartsProps) {

--- a/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
@@ -13,16 +13,21 @@ import {
 import { useApi } from '@services/api-service';
 import dayjs from 'dayjs';
 import { User } from '@interfaces/user';
+import { AgreementData } from '@interfaces/agreement';
 import { Aggregation, Category, MergedStatisticsMeasurementData } from '@interfaces/measurement-data';
 import { ExportStatisticsButton } from '@layouts/pages/mypages-sections/statistics/export-statistics-button/export-statistics-button.component';
 import { OnlyTrade } from '../../overview/consumption/only-trade.component';
-import { pagedAgreementsHandler } from '@services/agreement-service';
 import { EventLog } from '@layouts/pages/mypages-sections/statistics/event-log/event-log.component';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { getCategoryFromInstalledBaseType } from '@utils/facility';
 
-export default function Charts() {
+export interface ChartsProps {
+  allAgreements: AgreementData;
+  isAllAgreementsDone: boolean;
+}
+
+export default function Charts({ allAgreements, isAllAgreementsDone }: ChartsProps) {
   const { watch, setValue } = useFormContext();
   const { facilityId, toDate, fromDate, year } = watch();
   const [onlyTrade, setOnlyTrade] = useState(false);
@@ -36,13 +41,6 @@ export default function Charts() {
     method: 'get',
     url: '/me',
     queryKey: ['user'],
-  });
-
-  const { data: allAgreements } = useApi({
-    url: `/paged/all-agreements`,
-    method: 'get',
-    dataHandler: pagedAgreementsHandler,
-    queryKey: ['all-agreements'],
   });
 
   const categoryParam = useMemo(() => {
@@ -139,16 +137,18 @@ export default function Charts() {
     setValue('area', getAreaFromFacility(user?.facilities, facilityId));
     if (categoryForDisplay === 'Fjärrvärme') {
       setOnlyTrade(false);
-    } else {
-      const netAgreementExistsForFacility = allAgreements
-        ? Object.values(allAgreements ?? {})
-            .flat()
-            .some((agreement) => agreement.facilityId === facilityId && agreement.category.code === 'ELECTRICITY')
-        : false;
-
-      setOnlyTrade(!netAgreementExistsForFacility);
+      return;
     }
-  }, [facilityId, user?.facilities, allAgreements, setValue]);
+    const netAgreementExistsForFacility = Object.values(allAgreements ?? {})
+      .flat()
+      .some((agreement) => agreement.facilityId === facilityId && agreement.category.code === 'ELECTRICITY');
+
+    if (netAgreementExistsForFacility) {
+      setOnlyTrade(false);
+    } else if (isAllAgreementsDone) {
+      setOnlyTrade(true);
+    }
+  }, [facilityId, user?.facilities, allAgreements, isAllAgreementsDone, setValue]);
 
   useEffect(() => {
     if (measurementData && previousMeasurementData) {

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
@@ -4,7 +4,7 @@ import { InstalledBaseItem } from '@data-contracts/installedbase/data-contracts'
 import { User } from '@interfaces/user';
 import { generateComparableYears } from '@layouts/pages/mypages-sections/statistics/statistics-filter/generateDateLists';
 import { useApi } from '@services/api-service';
-import { Button, FormLabel, NavigationBar, Select } from '@sk-web-gui/react';
+import { Button, FormLabel, NavigationBar, ProgressBar, Select } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -17,6 +17,9 @@ import { useTranslation } from 'react-i18next';
 
 export interface StatisticsFilterProps {
   closeHandler: () => void;
+  isAllAgreementsDone: boolean;
+  allAgreementsCurrentPage: number;
+  allAgreementsTotalPages: number;
 }
 
 export const StatisticsFilter = (props: StatisticsFilterProps) => {
@@ -24,7 +27,7 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
   const linkedFacilityId = searchParams?.get('installation');
   const { t } = useTranslation(['common', 'statistics']);
 
-  const { closeHandler } = props;
+  const { closeHandler, isAllAgreementsDone, allAgreementsCurrentPage, allAgreementsTotalPages } = props;
   const { register, watch, setValue } = useFormContext<StatisticsForm>();
   const [facilities, setFacilities] = useState<InstalledBaseItem[]>();
   const [mode, setMode] = useState<'day' | 'month' | 'year'>('day');
@@ -130,7 +133,6 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
         <div className="flex flex-col lg:flex-row gap-16 items-end w-full lg:w-2/5 lg:pt-0 pt-24">
           <div className="block w-full">
             <FormLabel>{t('common:address')}</FormLabel>
-
             <Select {...register('address')} className="w-full mt-8" data-cy="address-select">
               {user?.addresses
                 ?.filter((a) => a.address)
@@ -141,6 +143,17 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
                   </Select.Option>
                 ))}
             </Select>
+            {!isAllAgreementsDone && (
+              <div className="flex gap-8 mt-8">
+                <ProgressBar
+                  current={allAgreementsCurrentPage}
+                  steps={allAgreementsTotalPages}
+                  size="md"
+                  color="vattjom"
+                  className="w-full"
+                />
+              </div>
+            )}
           </div>
 
           <div className="block w-full">

--- a/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/statistics-filter/statistics-filter.component.tsx
@@ -17,9 +17,11 @@ import { useTranslation } from 'react-i18next';
 
 export interface StatisticsFilterProps {
   closeHandler: () => void;
-  isAllAgreementsDone: boolean;
-  allAgreementsCurrentPage: number;
-  allAgreementsTotalPages: number;
+  allAgreements: {
+    isDone: boolean;
+    currentPage: number;
+    totalPages: number;
+  };
 }
 
 export const StatisticsFilter = (props: StatisticsFilterProps) => {
@@ -27,7 +29,7 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
   const linkedFacilityId = searchParams?.get('installation');
   const { t } = useTranslation(['common', 'statistics']);
 
-  const { closeHandler, isAllAgreementsDone, allAgreementsCurrentPage, allAgreementsTotalPages } = props;
+  const { closeHandler, allAgreements } = props;
   const { register, watch, setValue } = useFormContext<StatisticsForm>();
   const [facilities, setFacilities] = useState<InstalledBaseItem[]>();
   const [mode, setMode] = useState<'day' | 'month' | 'year'>('day');
@@ -143,11 +145,11 @@ export const StatisticsFilter = (props: StatisticsFilterProps) => {
                   </Select.Option>
                 ))}
             </Select>
-            {!isAllAgreementsDone && (
+            {!allAgreements.isDone && (
               <div className="flex gap-8 mt-8">
                 <ProgressBar
-                  current={allAgreementsCurrentPage}
-                  steps={allAgreementsTotalPages}
+                  current={allAgreements.currentPage}
+                  steps={allAgreements.totalPages}
                   size="md"
                   color="vattjom"
                   className="w-full"

--- a/frontend/src/utils/use-paged-agreements.hook.ts
+++ b/frontend/src/utils/use-paged-agreements.hook.ts
@@ -3,7 +3,7 @@ import { AgreementData, PagedAgreementsResponse } from '@interfaces/agreement';
 import { handlePagedAgreementsResponse } from '@services/agreement-service';
 import { apiService, ApiResponse } from '@services/api-service';
 
-export function usePagedAgreements(pageLimit: number) {
+export function usePagedAgreements(pageLimit: number, includeInactive: boolean = false) {
   const [agreements, setAgreements] = useState<AgreementData>({});
   const [isFetching, setIsFetching] = useState(true);
   const [isDone, setIsDone] = useState(false);
@@ -21,6 +21,7 @@ export function usePagedAgreements(pageLimit: number) {
 
   useEffect(() => {
     let cancelled = false;
+    const path = includeInactive ? '/paged/all-agreements' : '/paged/agreements';
 
     const fetchPages = async () => {
       let totalPages = 1;
@@ -28,7 +29,7 @@ export function usePagedAgreements(pageLimit: number) {
       try {
         for (let page = 1; page <= totalPages && !cancelled; page++) {
           const res = await apiService.get<ApiResponse<PagedAgreementsResponse>>(
-            `/paged/agreements?page=${page}&limit=${pageLimit}`
+            `${path}?page=${page}&limit=${pageLimit}`
           );
 
           const pageData = res.data.data;
@@ -57,7 +58,7 @@ export function usePagedAgreements(pageLimit: number) {
     return () => {
       cancelled = true;
     };
-  }, [mergeAgreements, pageLimit]);
+  }, [mergeAgreements, pageLimit, includeInactive]);
 
   return { agreements, isFetching, isDone, currentPage, totalPages, error };
 }


### PR DESCRIPTION
# Pull Request

## Description

Statistik hämtade samtliga avtal (_/paged/all-agreements_) i ett enda anrop. Användare med många avtal fick vänta tills allt hämtats  och under tiden flashades "Endast elhandel"-vyn felaktigt eftersom `allAgreements` var `undefined` från början

Fixar detta på samma sätt som infördes i _consumption.component_ ([HYDRAN-1864](https://jira.sundsvall.se/browse/HYDRAN-1864)). `agreements` hämtas paginerat och `onlyTrade`-checken sker per sida utan att flippa under laddning

Nu när Statistik öppnas ska statistiken bygga på samtliga avtal/anläggningar, så att siffror och totalen stämmer

Alla avtal laddas in (inklusive historiska), bara fördelat över flera sidor med progress-komponenten. Slutresultatet borde vara precis som tidigare

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-1865

## General Checklist

- [ ] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [ ] Project builds locally without errors
- [ ] ESLint/Prettier have been run and are OK
- [ ] API changes are documented (OpenAPI/README)
- [ ] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [ ] All affected pages render correctly (SSR/CSR)
- [ ] Navigation works
- [ ] API calls from the frontend continue to work
- [ ] Any forms/flows function correctly
- [ ] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [ ] Affected endpoints behave as expected
- [ ] No changes break existing contracts
- [ ] Error handling works correctly
- [ ] Logging behaves normally
- [ ] Protected endpoints validated (auth/session/JWT)
