### PR TITLE
fix/hydran 2560 prevent december of previous year leaking into year comparison c…

### DIFF
--- a/frontend/src/services/measurement-data-service.ts
+++ b/frontend/src/services/measurement-data-service.ts
@@ -71,22 +71,38 @@ export const handleStatisticsMeasurementDataResponse: (data: Data) => Statistics
     return newPoints;
   };
 
+  const filterPointsToRange: (series: MeasurementSerie) => void = (series) => {
+    if (!data?.fromDate || !series?.measurementPoints) {
+      return;
+    }
+    const from = dayjs(data.fromDate);
+    const to = data.toDate ? dayjs(data.toDate) : undefined;
+    series.measurementPoints = series.measurementPoints.filter((point) => {
+      const timestamp = dayjs(point.timestamp);
+      return !timestamp.isBefore(from) && !(to && timestamp.isAfter(to));
+    });
+  };
+
   const measurementData =
     data?.measurementSeries?.filter(
       (measurement) => measurement.unit === 'kWh' && measurement.measurementType !== CORRECTED_USAGE_TYPE
     ) ?? [];
+  measurementData.forEach(filterPointsToRange);
   measurementData.forEach(addTimestamps);
   measurementData.forEach(addQuarterValues);
 
   const correctedUsageData =
     data?.measurementSeries?.filter((measurement) => measurement.measurementType === CORRECTED_USAGE_TYPE) ?? [];
+  correctedUsageData.forEach(filterPointsToRange);
 
   const peakHourUsage =
     data?.measurementSeries?.filter((measurement) => measurement.measurementType === 'Peakhourusage') ?? [];
+  peakHourUsage.forEach(filterPointsToRange);
   peakHourUsage.forEach(addTimestamps);
 
   const temperatureData =
     data?.measurementSeries?.filter((measurement) => measurement.measurementType === 'outdoor_temperature') ?? [];
+  temperatureData.forEach(filterPointsToRange);
   temperatureData.forEach(addTimestamps);
 
   temperatureData.forEach((series) =>

--- a/frontend/src/services/measurement-data-service.ts
+++ b/frontend/src/services/measurement-data-service.ts
@@ -75,8 +75,9 @@ export const handleStatisticsMeasurementDataResponse: (data: Data) => Statistics
     if (!data?.fromDate || !series?.measurementPoints) {
       return;
     }
-    const from = dayjs(data.fromDate);
-    const to = data.toDate ? dayjs(data.toDate) : undefined;
+    // Compare on day boundaries so a date-only toDate (parsed as midnight) still covers the whole day.
+    const from = dayjs(data.fromDate).startOf('day');
+    const to = data.toDate ? dayjs(data.toDate).endOf('day') : undefined;
     series.measurementPoints = series.measurementPoints.filter((point) => {
       const timestamp = dayjs(point.timestamp);
       return !timestamp.isBefore(from) && !(to && timestamp.isAfter(to));


### PR DESCRIPTION
# Pull Request

## Description

The consumption statistics chart placed December of the *previous* year inside the
*current* year's bar when comparing two years (e.g. comparing 2026 with 2025 showed
December 2025's value in the December 2026 bar).

The WSO2 `/measurementdata` endpoint sometimes returns `measurementPoints` whose
timestamp falls outside the requested `fromDate`/`toDate` window. Because monthly
points are matched by month-number only (`MM`) in `mergeMeasurementDataSets`, a stray
`2025-12-01` point in the 2026 series was matched into the December 2026 bucket.

This adds a defensive `filterPointsToRange` step in `handleStatisticsMeasurementDataResponse`
that drops any point outside the requested window. Filtering at the response handler (rather
than only at the chart) keeps the chart, table, total, average and peak consumption all
consistent on the same in-range subset. Applied to all series (consumption, corrected-usage,
peak-hour and temperature).

## Background & Motivation

Reported bug: when selecting "Jämför med år" with 2026 vs 2025, the value for December 2025
appeared in the bar for 2026. DevTools inspection confirmed the API response for the 2026
series contained a `2025-12-01` point before the real `2026-01-01` point.

Jira: [HYDRAN-2560](https://jira.sundsvall.se/browse/HYDRAN-2560)

## General Checklist

- [x] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
