### PR TITLE
fix/hydran 2560 send UTC date boundaries for year view to stop WSO2 dropping edges

### DIFF
--- a/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
@@ -28,6 +28,16 @@ export interface ChartsProps {
   readonly isAllAgreementsDone: boolean;
 }
 
+const formatRequestBoundary = (date: dayjs.Dayjs, edge: 'start' | 'end', utcBoundaries: boolean): string => {
+  if (utcBoundaries) {
+    const utcDay = dayjs.utc(date.format('YYYY-MM-DD'));
+    const bounded = edge === 'start' ? utcDay.startOf('date') : utcDay.endOf('date');
+    return bounded.format('YYYY-MM-DDTHH:mm:ss[Z]');
+  }
+  const bounded = edge === 'start' ? date.startOf('date') : date.endOf('date');
+  return bounded.format();
+};
+
 export default function Charts({ allAgreements, isAllAgreementsDone }: ChartsProps) {
   const { watch, setValue } = useFormContext();
   const { facilityIds, toDate, fromDate, year, category } = watch();
@@ -64,24 +74,28 @@ export default function Charts({ allAgreements, isAllAgreementsDone }: ChartsPro
     return aggregationType;
   }, [fromDate, toDate, isHourQuarter, categoryParam]);
 
+  const useUtcBoundaries = aggregateOnParam === Aggregation.MONTH;
+
   const fromDateParam = useMemo(() => {
-    return dayjs(fromDate).startOf('date').format();
-  }, [fromDate]);
+    return formatRequestBoundary(dayjs(fromDate), 'start', useUtcBoundaries);
+  }, [fromDate, useUtcBoundaries]);
   const toDateParam = useMemo(() => {
-    return dayjs(toDate).endOf('date').format();
-  }, [toDate]);
+    return formatRequestBoundary(dayjs(toDate), 'end', useUtcBoundaries);
+  }, [toDate, useUtcBoundaries]);
   const fromDatePreviousParam = useMemo(() => {
-    return dayjs(fromDate)
-      .subtract(parseInt(dayjs(fromDate).format('YYYY')) - year, 'year')
-      .startOf('date')
-      .format();
-  }, [fromDate, year]);
+    return formatRequestBoundary(
+      dayjs(fromDate).subtract(parseInt(dayjs(fromDate).format('YYYY')) - year, 'year'),
+      'start',
+      useUtcBoundaries
+    );
+  }, [fromDate, year, useUtcBoundaries]);
   const toDatePreviousParam = useMemo(() => {
-    return dayjs(toDate)
-      .subtract(parseInt(dayjs(toDate).format('YYYY')) - year, 'year')
-      .endOf('date')
-      .format();
-  }, [toDate, year]);
+    return formatRequestBoundary(
+      dayjs(toDate).subtract(parseInt(dayjs(toDate).format('YYYY')) - year, 'year'),
+      'end',
+      useUtcBoundaries
+    );
+  }, [toDate, year, useUtcBoundaries]);
 
   const buildParamsString = (
     categoryParam: string,
@@ -150,9 +164,7 @@ export default function Charts({ allAgreements, isAllAgreementsDone }: ChartsPro
     }
     const netAgreementExistsForFacility = Object.values(allAgreements ?? {})
       .flat()
-      .some(
-        (agreement) => facilityIds?.includes(agreement.facilityId) && agreement.category.code === 'ELECTRICITY'
-      );
+      .some((agreement) => facilityIds?.includes(agreement.facilityId) && agreement.category.code === 'ELECTRICITY');
 
     if (netAgreementExistsForFacility) {
       setOnlyTrade(false);

--- a/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/statistics/charts/charts.component.tsx
@@ -84,14 +84,14 @@ export default function Charts({ allAgreements, isAllAgreementsDone }: ChartsPro
   }, [toDate, useUtcBoundaries]);
   const fromDatePreviousParam = useMemo(() => {
     return formatRequestBoundary(
-      dayjs(fromDate).subtract(parseInt(dayjs(fromDate).format('YYYY')) - year, 'year'),
+      dayjs(fromDate).subtract(Number.parseInt(dayjs(fromDate).format('YYYY')) - year, 'year'),
       'start',
       useUtcBoundaries
     );
   }, [fromDate, year, useUtcBoundaries]);
   const toDatePreviousParam = useMemo(() => {
     return formatRequestBoundary(
-      dayjs(toDate).subtract(parseInt(dayjs(toDate).format('YYYY')) - year, 'year'),
+      dayjs(toDate).subtract(Number.parseInt(dayjs(toDate).format('YYYY')) - year, 'year'),
       'end',
       useUtcBoundaries
     );


### PR DESCRIPTION
# Pull Request

## Description

In the statistics **year view** (and its year-over-year comparison), the consumption chart was
dropping the edge months — most visibly **December**, which disappeared entirely from the chart.

The outgoing `/measurementdata` request built its `fromDate`/`toDate` boundaries with
`dayjs(...).format()`, which emits the **browser's local timezone offset**
(`2025-01-01T00:00:00+01:00` / `...+02:00`). WSO2 buckets the request against those
offset-shifted instants and shaves off the boundary months before the data ever reaches us.

This change formats the boundaries as **UTC (`Z`)** — but **only for the `MONTH` aggregation**
(the year/comparison view), where months align to date edges. Day/hour/quarter views keep the
local offset, where it correctly aligns the intraday window, so they are unaffected.

- `frontend/.../statistics/charts/charts.component.tsx`
  - New `formatRequestBoundary(date, edge, utcBoundaries)` helper.
  - `fromDate`/`toDate` (current + previous-year comparison) emit `T00:00:00Z` / `T23:59:59Z`
    when `aggregateOn === MONTH`, otherwise unchanged.

> ⚠️ **I believe this is a temporary, frontend-side workaround.** The permanent fix belongs with
> the **API team**: the `/measurementdata` endpoint should interpret the request date range
> correctly regardless of the timezone offset sent by the client, instead of dropping boundary
> months. This PR unblocks the chart in the meantime, but the request-side handling should be
> made robust on the API.

## Background & Motivation

Reported follow-up on HYDRAN-2560 (December missing from the year view). Earlier fixes for this
ticket only patched the **response** side (filtering leaked previous-year December); the request
was still asking WSO2 with local-offset boundaries, so the API was under-returning. This addresses
the request side.

Jira: [HYDRAN-2560](https://jira.sundsvall.se/browse/HYDRAN-2560)

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
