### PR TITLE
feat/hydran 2550 add activity view entry and route scaffold

### DIFF
--- a/frontend/locales/sv/activity.json
+++ b/frontend/locales/sv/activity.json
@@ -1,0 +1,8 @@
+{
+  "title": "Aktivitet",
+  "description": "Här ser du kontots aktivitet de senaste 36 månaderna. Exportlogg för statistik hittar du under Statistik.",
+  "card": {
+    "title": "Aktivitet",
+    "description": "Se inloggningar och HAN-portändringar på ditt konto."
+  }
+}

--- a/frontend/locales/sv/paths.json
+++ b/frontend/locales/sv/paths.json
@@ -43,6 +43,10 @@
     "title": "Profil",
     "description": "Profil"
   },
+  "aktivitet": {
+    "title": "Aktivitet",
+    "description": "Aktivitet"
+  },
   "sjalvservice": {
     "title": "Självservice",
     "description": "Självservice"

--- a/frontend/src/app/[locale]/[mode]/(mypages-sections)/aktivitet/page.tsx
+++ b/frontend/src/app/[locale]/[mode]/(mypages-sections)/aktivitet/page.tsx
@@ -1,0 +1,5 @@
+import { ActivityComponent } from '@layouts/pages/mypages-sections/activity/activity.component';
+
+export default function Aktivitet() {
+  return <ActivityComponent />;
+}

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ const namespaces = [
   'ai',
   'about',
   'accessibility',
+  'activity',
   'agreement',
   'category',
   'common',

--- a/frontend/src/layouts/pages/mypages-sections/activity/activity.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/activity/activity.component.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { PagesBreadcrumbsLayout } from '@layouts/pages-breadcrumbs-layout.component';
+import { Breadcrumb } from '@sk-web-gui/react';
+import NextLink from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+export const ActivityComponent = () => {
+  const { t } = useTranslation(['activity', 'profile']);
+
+  return (
+    <PagesBreadcrumbsLayout
+      breadcrumbs={
+        <Breadcrumb>
+          <Breadcrumb.Item>
+            <NextLink href="profil">
+              <Breadcrumb.Link variant="body" as="span">
+                {t('profile:title')}
+              </Breadcrumb.Link>
+            </NextLink>
+          </Breadcrumb.Item>
+          <Breadcrumb.Item currentPage>
+            <Breadcrumb.Link href="./">{t('activity:title')}</Breadcrumb.Link>
+          </Breadcrumb.Item>
+        </Breadcrumb>
+      }
+    >
+      <section className="flex flex-col gap-16">
+        <h1 className="mb-0 text-display-3-md text-dark-primary">{t('activity:title')}</h1>
+        <p className="m-0 text-large text-dark-primary font-normal">{t('activity:description')}</p>
+      </section>
+    </PagesBreadcrumbsLayout>
+  );
+};

--- a/frontend/src/layouts/pages/mypages-sections/profile/components/profile-link-card.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/profile/components/profile-link-card.component.tsx
@@ -1,0 +1,26 @@
+import { Icon } from '@sk-web-gui/react';
+import { ChevronRight } from 'lucide-react';
+import NextLink from 'next/link';
+
+interface ProfileLinkCardProps {
+  title: string;
+  subTitle: string;
+  href: string;
+  'data-cy'?: string;
+}
+
+export const ProfileLinkCard: React.FC<ProfileLinkCardProps> = ({ title, subTitle, href, ...rest }) => {
+  return (
+    <NextLink
+      href={href}
+      className="bg-background-content px-24 py-20 rounded-button shadow-50 flex items-center justify-between gap-16 no-underline"
+      {...rest}
+    >
+      <span className="flex flex-col gap-4">
+        <h2 className="text-h4-md m-0">{title}</h2>
+        <p className="text-base font-normal m-0">{subTitle}</p>
+      </span>
+      <Icon icon={<ChevronRight />} />
+    </NextLink>
+  );
+};

--- a/frontend/src/layouts/pages/mypages-sections/profile/profile.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/profile/profile.component.tsx
@@ -6,12 +6,13 @@ import { Divider } from '@sk-web-gui/react';
 import { useTranslation } from 'react-i18next';
 import { Mandates } from './components/mandates/mandates.component';
 import { ProfileAccordion } from './components/profile-accordion.component';
+import { ProfileLinkCard } from './components/profile-link-card.component';
 import { ContactDetails } from './profile-contact-details.component';
 import { ContactSettings } from './profile-contact-settings.component';
 import { DelegatedContactDetails } from './profile-delegate-details.component';
 
 export const Profile = () => {
-  const { t } = useTranslation('profile');
+  const { t } = useTranslation(['profile', 'activity']);
   const { isRepresentingModeBusiness, isRepresentingModePrivate } = useAppContext();
   return (
     <div className="flex flex-col gap-24">
@@ -47,6 +48,13 @@ export const Profile = () => {
       )}
 
       {isRepresentingModeBusiness && <Mandates />}
+
+      <ProfileLinkCard
+        data-cy="activity-link"
+        title={t('activity:card.title')}
+        subTitle={t('activity:card.description')}
+        href="aktivitet"
+      />
     </div>
   );
 };


### PR DESCRIPTION
# Pull Request

## Description

Adds the **Aktivitet** entry point and an empty page scaffold for the activity
view (no data yet — content comes in later subtasks).

- New route `aktivitet` under `(mypages-sections)`, so it inherits the same
  auth/layout as the other settings pages.
- New `ActivityComponent` — breadcrumb (**Din profil och inställningar / Aktivitet**),
  H1 and intro text, using `PagesBreadcrumbsLayout` like the agreement sub-page.
- New `ProfileLinkCard` — a clickable card (title + subtitle + `›`) mirroring
  `ProfileAccordion` styling, since this entry navigates rather than expands.
- Wires the card into the settings page (`data-cy="activity-link"`), shown in both
  private and business mode.
- i18n: new `activity` namespace + `paths.aktivitet` entry for page-title metadata.

## Background & Motivation

Frontend entry point for the activity view ([HYDRAN-1821](https://jira.sundsvall.se/browse/HYDRAN-1821)). Subtask [HYDRAN-2550](https://jira.sundsvall.se/browse/HYDRAN-2550).

**Notes:** scaffold only — the activity list, filters and data fetching come in
later subtasks. The card is shown in both modes (account activity applies to both);
easy to gate to private-only if preferred.

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
