### PR TITLE
Feat/hydran 2552 activity item card

### DIFF
--- a/frontend/locales/sv/activity.json
+++ b/frontend/locales/sv/activity.json
@@ -1,0 +1,15 @@
+{
+  "item": {
+    "company": "Företag",
+    "supportReason": "Supportanledning",
+    "address": "Adress",
+    "facilityId": "Anläggnings-ID",
+    "timestamp": "Tidpunkt"
+  },
+  "badge": {
+    "login": "Inloggning",
+    "impersonation": "Kundtjänst",
+    "hanActivated": "HAN-port aktiverad",
+    "hanDeactivated": "HAN-port inaktiverad"
+  }
+}

--- a/frontend/src/layouts/pages/mypages-sections/activity/activity.types.ts
+++ b/frontend/src/layouts/pages/mypages-sections/activity/activity.types.ts
@@ -1,0 +1,14 @@
+export type ActivityType = 'login' | 'impersonation' | 'hanActivated' | 'hanDeactivated';
+
+export interface ActivityItem {
+  id: string;
+  type: ActivityType;
+  name: string;
+  personNumber: string;
+  timestamp: string;
+  organizationName?: string;
+  supportReason?: string;
+  /** HAN-port events: address, facilityId */
+  address?: string;
+  facilityId?: string;
+}

--- a/frontend/src/layouts/pages/mypages-sections/activity/components/activity-badge.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/activity/components/activity-badge.component.tsx
@@ -1,0 +1,29 @@
+import { Label } from '@sk-web-gui/react';
+import { useTranslation } from 'react-i18next';
+import { ActivityType } from '../activity.types';
+
+type LabelColor = React.ComponentProps<typeof Label>['color'];
+
+const BADGE: Record<ActivityType, { color: LabelColor; inverted: boolean }> = {
+  login: { color: 'tertiary', inverted: true },
+  impersonation: { color: 'tertiary', inverted: false },
+  hanActivated: { color: 'gronsta', inverted: true },
+  hanDeactivated: { color: 'error', inverted: true },
+};
+
+export const ActivityBadge = ({ activityType }: { activityType: ActivityType }) => {
+  const { t } = useTranslation('activity');
+  const { color, inverted } = BADGE[activityType];
+
+  return (
+    <Label
+      rounded
+      color={color}
+      inverted={inverted}
+      className="whitespace-nowrap"
+      data-cy={`activity-badge-${activityType}`}
+    >
+      {t(`activity:badge.${activityType}`)}
+    </Label>
+  );
+};

--- a/frontend/src/layouts/pages/mypages-sections/activity/components/activity-list-item.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/activity/components/activity-list-item.component.tsx
@@ -49,16 +49,16 @@ export const ActivityListItem = ({ item }: ActivityListItemProps) => {
   return (
     <div
       data-cy="activity-list-item"
-      className="flex flex-col-reverse gap-8 rounded-cards bg-background-color-mixin-1 p-20 sm:flex-row sm:items-start sm:justify-between sm:gap-16"
+      className="flex flex-col-reverse gap-8 rounded-cards bg-background-color-mixin-1 p-16 sm:flex-row sm:items-center sm:justify-between sm:gap-16"
     >
-      <div className="flex flex-col gap-4">
-        <p className="m-0">
+      <div className="flex flex-col gap-4 text-dark-secondary">
+        <p className="m-0 text-dark-primary">
           <strong>{item.name}</strong>, {item.personNumber}
         </p>
         {renderDetails()}
         <p className="m-0">
           <strong>{t('activity:item.timestamp')}:</strong>{' '}
-          {dayjs(item.timestamp).format('DD MMMM YYYY, kl HH.mm').toLowerCase()}
+          {dayjs(item.timestamp).format('DD MMMM YYYY, kl. HH.mm').toLowerCase()}
         </p>
       </div>
       <div className="sm:shrink-0">

--- a/frontend/src/layouts/pages/mypages-sections/activity/components/activity-list-item.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/activity/components/activity-list-item.component.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import dayjs from 'dayjs';
+import { useTranslation } from 'react-i18next';
+import { ActivityItem } from '../activity.types';
+import { ActivityBadge } from './activity-badge.component';
+
+interface ActivityListItemProps {
+  item: ActivityItem;
+}
+
+export const ActivityListItem = ({ item }: ActivityListItemProps) => {
+  const { t } = useTranslation('activity');
+
+  const renderDetails = () => {
+    switch (item.type) {
+      case 'login':
+        return item.organizationName ? (
+          <p className="m-0">
+            <strong>{t('activity:item.company')}:</strong> {item.organizationName}
+          </p>
+        ) : null;
+      case 'impersonation':
+        return item.supportReason ? (
+          <p className="m-0">
+            <strong>{t('activity:item.supportReason')}:</strong> {item.supportReason}
+          </p>
+        ) : null;
+      case 'hanActivated':
+      case 'hanDeactivated':
+        return (
+          <div className="flex flex-col gap-4 sm:flex-row sm:gap-0">
+            {item.address && (
+              <p className="m-0">
+                <strong>{t('activity:item.address')}:</strong> {item.address}
+              </p>
+            )}
+            {item.facilityId && (
+              <p className="m-0">
+                {item.address && <span className="hidden sm:inline">, </span>}
+                <strong>{t('activity:item.facilityId')}:</strong> {item.facilityId}
+              </p>
+            )}
+          </div>
+        );
+    }
+  };
+
+  return (
+    <div
+      data-cy="activity-list-item"
+      className="flex flex-col-reverse gap-8 rounded-cards bg-background-color-mixin-1 p-20 sm:flex-row sm:items-start sm:justify-between sm:gap-16"
+    >
+      <div className="flex flex-col gap-4">
+        <p className="m-0">
+          <strong>{item.name}</strong>, {item.personNumber}
+        </p>
+        {renderDetails()}
+        <p className="m-0">
+          <strong>{t('activity:item.timestamp')}:</strong>{' '}
+          {dayjs(item.timestamp).format('DD MMMM YYYY, kl HH.mm').toLowerCase()}
+        </p>
+      </div>
+      <div className="sm:shrink-0">
+        <ActivityBadge activityType={item.type} />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
# Pull Request

## Description

Adds the presentational **activity item card** + **type badge** for the activity view.
Pure components — not yet rendered anywhere in the app (the page wiring is a later subtask).

- `ActivityListItem` — name (black) + masked personnummer, per-type fields
  (Företag / Supportanledning / Adress + Anläggnings-ID, the other lines in the
  secondary text tone), and the timestamp.
- `ActivityBadge` — type→colour map (Inloggning tertriary inverted/ Kundtjänst tertriary /
  HAN-port aktiverad gronska inverted/ inaktiverad error inverted).
- Responsive per the design: badge top on mobile / right-centered on desktop;
  Anläggnings-ID on its own row on mobile, inline (comma-separated) on desktop.
- Draft `ActivityItem` type + `item`/`badge` i18n keys.

## Background & Motivation

Activity card UI for the activity view ([HYDRAN-1821](https://jira.sundsvall.se/browse/HYDRAN-1821)). Subtask [HYDRAN-2552](https://jira.sundsvall.se/browse/HYDRAN-2552).

**Note:** Dates follow the app-wide convention.


## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
