### PR TITLE
feat/hydran-2553 add reusable year/month timeline component

### DIFF
--- a/frontend/src/components/timeline/timeline.component.tsx
+++ b/frontend/src/components/timeline/timeline.component.tsx
@@ -1,0 +1,57 @@
+import { Badge } from '@sk-web-gui/react';
+import dayjs from 'dayjs';
+import { ReactNode } from 'react';
+
+export type MonthNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
+export interface TimelineMonth {
+  month: MonthNumber;
+  children: ReactNode;
+}
+
+export interface TimelineYear {
+  year: number;
+  months: TimelineMonth[];
+}
+
+interface TimelineProps {
+  years: TimelineYear[];
+}
+
+const monthName = (month: MonthNumber) => {
+  const name = dayjs()
+    .month(month - 1)
+    .format('MMMM');
+  return name.charAt(0).toUpperCase() + name.slice(1);
+};
+
+export const Timeline = ({ years }: TimelineProps) => {
+  return (
+    <div className="flex flex-col gap-64" data-cy="timeline">
+      {years.map((year) => (
+        <section key={year.year} className="flex flex-col gap-16 sm:gap-32">
+          <h2 className="m-0 text-lead font-sans font-bold text-dark-primary">{year.year}</h2>
+
+          <div className="flex flex-col gap-32">
+            {year.months.map((month) => {
+              const label = monthName(month.month);
+              return (
+                <div key={month.month} className="flex flex-col gap-16 sm:flex-row sm:gap-24">
+                  <div className="hidden w-[74px] shrink-0 flex-col items-center gap-8 sm:flex">
+                    <Badge aria-hidden color="error" inverted />
+                    <span className="text-dark-primary">{label}</span>
+                    <span aria-hidden className="w-2 grow bg-gray-200" />
+                  </div>
+
+                  <span className="text-dark-primary sm:hidden font-normal">{label}</span>
+
+                  <div className="flex min-w-0 flex-1 flex-col gap-16">{month.children}</div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
# Pull Request

## Description

Adds a reusable **year → month timeline** component (`src/components/timeline`).

- Vertical line with a badge (cornet rounded square) per month, grouped by year, rendering **arbitrary children**.
- Restricted inputs: `year: number`, `month: 1–12` (`MonthNumber`); month names are localised.
- **Responsive:** the rail (badge + line + month name) on desktop; on mobile the rail is
  dropped and the month name renders as a plain heading above the cards.
- Built locally because `@sk-web-gui/progress-stepper` is a linear wizard and can't render
  grouped, equal entries with custom content.

## Background & Motivation

Local timeline for the activity view ([HYDRAN-1821](https://jira.sundsvall.se/browse/HYDRAN-1821)). Subtask [HYDRAN-2553](https://jira.sundsvall.se/browse/HYDRAN-2553).

**Note:** we use `@sk-web-gui` `Badge`; colours/spacing aligned to the Figma.
Wiring it to real data + pagination is a later subtask.


## General Checklist

- [x] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
