### PR TITLE
feat/hydran-2556 add activity service and response mapping

### DIFF
--- a/frontend/src/layouts/pages/mypages-sections/activity/activity.types.ts
+++ b/frontend/src/layouts/pages/mypages-sections/activity/activity.types.ts
@@ -1,3 +1,5 @@
+import { MonthNumber } from '@components/timeline/timeline.component';
+
 export type ActivityType = 'login' | 'impersonation' | 'hanActivated' | 'hanDeactivated';
 
 export interface ActivityItem {
@@ -11,4 +13,20 @@ export interface ActivityItem {
   /** HAN-port events: address, facilityId */
   address?: string;
   facilityId?: string;
+}
+
+export interface ActivityMonthGroup {
+  month: MonthNumber;
+  items: ActivityItem[];
+}
+
+export interface ActivityYearGroup {
+  year: number;
+  months: ActivityMonthGroup[];
+}
+
+export interface ActivityData {
+  years: ActivityYearGroup[];
+  totalPages: number;
+  totalElements: number;
 }

--- a/frontend/src/services/activity-service.ts
+++ b/frontend/src/services/activity-service.ts
@@ -1,0 +1,122 @@
+import { EventMetaData, EventResponse, PagedEventsResponse } from '@data-contracts/backend/data-contracts';
+import { MonthNumber } from '@components/timeline/timeline.component';
+import { useApi } from '@services/api-service';
+import {
+  ActivityData,
+  ActivityItem,
+  ActivityType,
+  ActivityYearGroup,
+} from '@layouts/pages/mypages-sections/activity/activity.types';
+import dayjs from 'dayjs';
+
+interface ActivityQuery {
+  activityTypeFilter: string;
+  from: string;
+  to: string;
+}
+
+type Meta = Record<string, string>;
+
+const toMeta = (metadata: EventMetaData[]): Meta => Object.fromEntries(metadata.map(({ key, value }) => [key, value]));
+
+const toActivityType = (sourceType: string | null | undefined, meta: Meta): ActivityType => {
+  switch (sourceType) {
+    case 'Login':
+      return 'login';
+    case 'Impersonation':
+      return 'impersonation';
+    case 'HAN':
+      // TODO(HYDRAN-1821): confirm the HAN aktiverad/inaktiverad signal from the BFUS->eventlog writer.
+      return meta.operation === 'revoke' ? 'hanDeactivated' : 'hanActivated';
+    default:
+      return 'login';
+  }
+};
+
+const mapEvent = (event: EventResponse, index: number): ActivityItem => {
+  const meta = toMeta(event.metadata as unknown as EventMetaData[]);
+  const type = toActivityType(event.sourceType, meta);
+  const base = { id: `${event.created ?? ''}-${index}`, type, timestamp: event.created ?? '' };
+
+  switch (type) {
+    case 'login':
+      return {
+        ...base,
+        name: meta.loggedInUserName ?? '',
+        personNumber: meta.loggedInUserPersonNumber ?? '',
+        organizationName: meta.organizationName,
+      };
+    case 'impersonation':
+      return {
+        ...base,
+        name: meta.requestedByName ?? '',
+        personNumber: meta.requestedByPersonNumber ?? '',
+        supportReason: meta.accessReason,
+      };
+    case 'hanActivated':
+    case 'hanDeactivated':
+      return {
+        ...base,
+        name: meta.loggedInUserName ?? '',
+        personNumber: meta.personNumber ?? '',
+        address: meta.address,
+        facilityId: meta.facilityId,
+      };
+  }
+};
+
+const groupByYearMonth = (items: ActivityItem[]): ActivityYearGroup[] => {
+  const years = new Map<number, Map<MonthNumber, ActivityItem[]>>();
+
+  for (const item of items) {
+    const date = dayjs(item.timestamp);
+    const year = date.year();
+    const month = (date.month() + 1) as MonthNumber;
+
+    const months = years.get(year) ?? new Map<MonthNumber, ActivityItem[]>();
+    months.set(month, [...(months.get(month) ?? []), item]);
+    years.set(year, months);
+  }
+
+  return [...years.entries()]
+    .sort(([a], [b]) => b - a)
+    .map(([year, months]) => ({
+      year,
+      months: [...months.entries()]
+        .sort(([a], [b]) => b - a)
+        .map(([month, monthItems]) => ({ month, items: monthItems })),
+    }));
+};
+
+export const mapActivityResponse = (data: PagedEventsResponse): ActivityData => {
+  const events = (data.content ?? []) as EventResponse[];
+  return {
+    years: groupByYearMonth(events.map(mapEvent)),
+    totalPages: data.totalPages ?? 0,
+    totalElements: data.totalElements ?? 0,
+  };
+};
+
+interface UseActivityOptions {
+  page?: number;
+  size?: number;
+}
+
+export const useActivity = (filter: ActivityQuery, { page = 0, size = 20 }: UseActivityOptions = {}) => {
+  const params = new URLSearchParams({
+    // The frontend `activityTypeFilter` maps to the backend `sourceTypeFilter` query param.
+    sourceTypeFilter: filter.activityTypeFilter,
+    page: String(page),
+    size: String(size),
+    sort: 'created,desc',
+  });
+  if (filter.from) params.append('from', filter.from);
+  if (filter.to) params.append('to', filter.to);
+
+  return useApi<PagedEventsResponse, Error, ActivityData>({
+    method: 'get',
+    url: `/event/activity?${params}`,
+    dataHandler: mapActivityResponse,
+    queryKey: ['activity', filter.activityTypeFilter, filter.from, filter.to, String(page), String(size)],
+  });
+};

--- a/frontend/src/services/activity-service.ts
+++ b/frontend/src/services/activity-service.ts
@@ -91,7 +91,7 @@ const groupByYearMonth = (items: ActivityItem[]): ActivityYearGroup[] => {
 export const mapActivityResponse = (data: PagedEventsResponse): ActivityData => {
   const events = (data.content ?? []) as EventResponse[];
   return {
-    years: groupByYearMonth(events.map(mapEvent)),
+    years: groupByYearMonth(events.map((event, index) => mapEvent(event, index))),
     totalPages: data.totalPages ?? 0,
     totalElements: data.totalElements ?? 0,
   };


### PR DESCRIPTION
# Pull Request

## Description

Adds the frontend **activity service**, fetching + mapping for the activity view.

- **`useActivity(filter, { page, size })`**, React Query hook (via `useApi`) that calls
  `GET /event/activity`, mapping the frontend `activityTypeFilter` → backend `sourceTypeFilter`
  plus `from`/`to`/pagination.
- **`mapActivityResponse`**, maps each eventlog `EventResponse` → `ActivityItem` by `sourceType`
  (Login → name/org, Impersonation → `requestedByName`/`accessReason`, HAN → placeholder), then
  groups them **year → month** (newest first) for the timeline.
- Adds the grouped types (`ActivityMonthGroup` / `ActivityYearGroup` / `ActivityData`).

<mark>_**Verified end-to-end against real data (impersonation events fetched, mapped, grouped, rendered).**_</mark>

## Background & Motivation

Jira ref. [**HYDRAN-2556**](https://jira.sundsvall.se/browse/HYDRAN-2556)

**Notes:**
- `personNumber` is read from metadata keys (`loggedInUserPersonNumber` / `requestedByPersonNumber`)
  that the write side (#311) still needs to add, blank until then.
- HAN aktiverad/inaktiverad reads a `meta.operation` key, TBD with the BFUS→eventlog writer.

## General Checklist

- [x] PR follows code style and standards
- [x] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
