### PR TITLE
Feat/hydran 2558 cypress tests

### DIFF
--- a/frontend/cypress/e2e/aktivitet.cy.ts
+++ b/frontend/cypress/e2e/aktivitet.cy.ts
@@ -1,0 +1,149 @@
+import { setIntercepts } from '../support/e2e';
+import { RepresentingMode } from '@interfaces/app';
+import dayjs from 'dayjs';
+import { getActivityEvents, getActivityEventsPageTwo, getEmptyActivityEvents } from '../fixtures/getActivityEvents';
+
+describe('Aktivitet', () => {
+  beforeEach(() => {
+    setIntercepts(RepresentingMode.PRIVATE);
+  });
+
+  const visitActivity = (response = getActivityEvents()) => {
+    cy.intercept('GET', '**/api/event/activity?**', response).as('getActivity');
+    cy.visit('/privat/aktivitet');
+    cy.get('#content').should('exist');
+    cy.get('h1').should('contain.text', 'Aktivitet');
+    cy.wait('@getActivity');
+  };
+
+  it('renders the page shell with filter and timeline', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-filter"]').should('exist');
+    cy.get('[data-cy="timeline"]').should('exist');
+    cy.get('[data-cy="activity-list-item"]').should('have.length.greaterThan', 0);
+    cy.get('[data-cy="timeline"]').should('include.text', '2026').should('include.text', '2025');
+  });
+
+  it('renders a login event with company and badge', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-badge-login"]').first().should('contain.text', 'Inloggning');
+    cy.get('[data-cy="activity-badge-login"]')
+      .first()
+      .closest('[data-cy="activity-list-item"]')
+      .should('include.text', 'Kalle Karlsson')
+      .should('include.text', 'Företag')
+      .should('include.text', 'Blåmesen AB');
+  });
+
+  it('renders a kundtjänst (impersonation) event with support reason', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-badge-impersonation"]').should('contain.text', 'Kundtjänst');
+    cy.get('[data-cy="activity-badge-impersonation"]')
+      .closest('[data-cy="activity-list-item"]')
+      .should('include.text', 'Ronny Lundberg')
+      .should('include.text', 'Supportanledning')
+      .should('include.text', 'I samtal med kunden');
+  });
+
+  it('renders HAN-port activated and deactivated events', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-badge-hanActivated"]')
+      .should('contain.text', 'HAN-port aktiverad')
+      .closest('[data-cy="activity-list-item"]')
+      .should('include.text', 'Adress')
+      .should('include.text', 'Kajvägen 10')
+      .should('include.text', 'Anläggnings-ID')
+      .should('include.text', '735999109515160509');
+
+    cy.get('[data-cy="activity-badge-hanDeactivated"]').should('contain.text', 'HAN-port inaktiverad');
+  });
+
+  it('omits the trailing comma when a personnummer is missing', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-badge-hanDeactivated"]')
+      .closest('[data-cy="activity-list-item"]')
+      .find('p')
+      .first()
+      .should('have.text', 'Mirsad Andersson');
+  });
+
+  it('filters by Inloggningar', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-filter-login"]').click();
+    cy.wait('@getActivity').its('request.query.sourceTypeFilter').should('eq', 'login');
+  });
+
+  it('filters by HAN-port', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-filter-han"]').click();
+    cy.wait('@getActivity').its('request.query.sourceTypeFilter').should('eq', 'han');
+  });
+
+  it('sends the selected period as from/to', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-filter-from"]').clear().type('2026-02-01');
+    cy.wait('@getActivity').its('request.query.from').should('eq', '2026-02-01');
+
+    cy.get('[data-cy="activity-filter-to"]').clear().type('2026-04-30');
+    cy.wait('@getActivity').its('request.query.to').should('eq', '2026-04-30');
+  });
+
+  it('pages through results on desktop', () => {
+    visitActivity();
+
+    cy.get('[data-cy="activity-pagination"]').should('exist');
+
+    cy.intercept('GET', '**/api/event/activity?**page=1**', getActivityEventsPageTwo()).as('getActivityPage2');
+    cy.get('[data-cy="activity-pagination"]').contains('2').click({ force: true });
+
+    cy.wait('@getActivityPage2').its('request.query.page').should('eq', '1');
+    cy.get('[data-cy="activity-list-item"]').should('include.text', 'Sven Svensson');
+  });
+
+  it('shows the empty state when there is no activity', () => {
+    visitActivity(getEmptyActivityEvents());
+
+    cy.get('[data-cy="activity-empty"]').should('exist');
+    cy.get('[data-cy="activity-list-item"]').should('not.exist');
+  });
+
+  it('shows the error state when the request fails', () => {
+    cy.intercept('GET', '**/api/event/activity?**', { statusCode: 503, body: {} }).as('getActivity');
+    cy.visit('/privat/aktivitet');
+    cy.get('h1').should('contain.text', 'Aktivitet');
+
+    cy.get('[data-cy="activity-error"]').should('exist');
+    cy.get('[data-cy="activity-list-item"]').should('not.exist');
+  });
+
+  it('pages by year on mobile', () => {
+    cy.viewport('iphone-x');
+    const currentYear = dayjs().year();
+
+    cy.intercept('GET', '**/api/event/activity?**', getActivityEvents()).as('getActivity');
+    cy.visit('/privat/aktivitet');
+    cy.get('h1').should('contain.text', 'Aktivitet');
+
+    cy.wait('@getActivity').its('request.query.from').should('eq', `${currentYear}-01-01`);
+
+    cy.get('[data-cy="activity-year-pagination"]').should('exist');
+    cy.get('[aria-label="Föregående år"]').should('be.disabled');
+
+    cy.get(`[data-cy="activity-year-${currentYear - 1}"]`).click();
+    cy.wait('@getActivity')
+      .its('request.query.from')
+      .should('eq', `${currentYear - 1}-01-01`);
+
+    cy.get(`[data-cy="activity-year-${currentYear - 3}"]`).click();
+    cy.wait('@getActivity');
+    cy.get('[aria-label="Nästa år"]').should('be.disabled');
+  });
+});

--- a/frontend/cypress/e2e/aktivitet.cy.ts
+++ b/frontend/cypress/e2e/aktivitet.cy.ts
@@ -102,7 +102,7 @@ describe('Aktivitet', () => {
     cy.get('[data-cy="activity-pagination"]').should('exist');
 
     cy.intercept('GET', '**/api/event/activity?**page=1**', getActivityEventsPageTwo()).as('getActivityPage2');
-    cy.get('[data-cy="activity-pagination"]').contains('2').click({ force: true });
+    cy.get('[data-cy="activity-pagination"]').contains('2').click();
 
     cy.wait('@getActivityPage2').its('request.query.page').should('eq', '1');
     cy.get('[data-cy="activity-list-item"]').should('include.text', 'Sven Svensson');

--- a/frontend/cypress/e2e/aktivitet.cy.ts
+++ b/frontend/cypress/e2e/aktivitet.cy.ts
@@ -43,7 +43,7 @@ describe('Aktivitet', () => {
     cy.get('[data-cy="activity-badge-impersonation"]').should('contain.text', 'Kundtjänst');
     cy.get('[data-cy="activity-badge-impersonation"]')
       .closest('[data-cy="activity-list-item"]')
-      .should('include.text', 'Ronny Lundberg')
+      .should('include.text', 'Maja Andersson')
       .should('include.text', 'Supportanledning')
       .should('include.text', 'I samtal med kunden');
   });

--- a/frontend/cypress/fixtures/getActivityEvents.ts
+++ b/frontend/cypress/fixtures/getActivityEvents.ts
@@ -1,0 +1,107 @@
+import { ApiResponse } from '@services/api-service';
+import { EventMetaData, PagedEventsResponse } from '@data-contracts/backend/data-contracts';
+
+interface ActivityEvent {
+  logKey: string;
+  type: 'ACCESS';
+  municipalityId: string;
+  message: string;
+  owner: string;
+  created: string;
+  sourceType: string;
+  metadata: EventMetaData[];
+}
+
+const event = (created: string, sourceType: string, metadata: EventMetaData[]): ActivityEvent => ({
+  logKey: '12345678-1234-1234-1234-1234567890ab',
+  type: 'ACCESS',
+  municipalityId: '2281',
+  message: sourceType,
+  owner: 'BolagenMinaSidor',
+  created,
+  sourceType,
+  metadata,
+});
+
+const paged = (
+  content: ActivityEvent[],
+  overrides: Partial<PagedEventsResponse> = {}
+): ApiResponse<PagedEventsResponse> => ({
+  data: {
+    content,
+    pageable: {
+      pageNumber: 0,
+      pageSize: 5,
+      sort: { sorted: true, empty: false, unsorted: false },
+      offset: 0,
+      paged: true,
+      unpaged: false,
+    },
+    last: true,
+    totalElements: content.length,
+    totalPages: 1,
+    size: 5,
+    number: 0,
+    sort: { sorted: true, empty: false, unsorted: false },
+    first: true,
+    numberOfElements: content.length,
+    empty: content.length === 0,
+    ...overrides,
+  },
+  message: 'success',
+});
+
+const LOGIN = event('2026-05-20T14:13:00.000Z', 'Login', [
+  { key: 'loggedInUserName', value: 'Kalle Karlsson' },
+  { key: 'loggedInUserPersonNumber', value: '199010100000' },
+  { key: 'organizationName', value: 'Blåmesen AB' },
+]);
+
+const IMPERSONATION = event('2026-05-18T09:46:00.000Z', 'Impersonation', [
+  { key: 'requestedByName', value: 'Ronny Lundberg' },
+  { key: 'requestedByPersonNumber', value: '198501011234' },
+  { key: 'accessReason', value: 'I samtal med kunden' },
+]);
+
+const HAN_ACTIVATED = event('2026-04-10T10:00:00.000Z', 'HAN', [
+  { key: 'operation', value: 'grant' },
+  { key: 'loggedInUserName', value: 'Mirsad Andersson' },
+  { key: 'personNumber', value: '199203033456' },
+  { key: 'address', value: 'Kajvägen 10' },
+  { key: 'facilityId', value: '735999109515160509' },
+]);
+
+const HAN_DEACTIVATED = event('2026-03-05T08:00:00.000Z', 'HAN', [
+  { key: 'operation', value: 'revoke' },
+  { key: 'loggedInUserName', value: 'Mirsad Andersson' },
+  { key: 'address', value: 'Kajvägen 10' },
+  { key: 'facilityId', value: '735999109515160509' },
+]);
+
+const LOGIN_PREVIOUS_YEAR = event('2025-12-01T11:00:00.000Z', 'Login', [
+  { key: 'loggedInUserName', value: 'Kalle Karlsson' },
+  { key: 'loggedInUserPersonNumber', value: '199010100000' },
+  { key: 'organizationName', value: 'Blåmesen AB' },
+]);
+
+export const getActivityEvents = (): ApiResponse<PagedEventsResponse> =>
+  paged([LOGIN, IMPERSONATION, HAN_ACTIVATED, HAN_DEACTIVATED, LOGIN_PREVIOUS_YEAR], {
+    totalElements: 8,
+    totalPages: 2,
+    last: false,
+  });
+
+export const getActivityEventsPageTwo = (): ApiResponse<PagedEventsResponse> =>
+  paged(
+    [
+      event('2026-01-15T07:30:00.000Z', 'Login', [
+        { key: 'loggedInUserName', value: 'Sven Svensson' },
+        { key: 'loggedInUserPersonNumber', value: '197001011111' },
+        { key: 'organizationName', value: 'Blåmesen AB' },
+      ]),
+    ],
+    { number: 1, first: false, last: true, totalElements: 8, totalPages: 2, numberOfElements: 1 }
+  );
+
+export const getEmptyActivityEvents = (): ApiResponse<PagedEventsResponse> =>
+  paged([], { totalElements: 0, totalPages: 0 });

--- a/frontend/cypress/fixtures/getActivityEvents.ts
+++ b/frontend/cypress/fixtures/getActivityEvents.ts
@@ -58,7 +58,7 @@ const LOGIN = event('2026-05-20T14:13:00.000Z', 'Login', [
 ]);
 
 const IMPERSONATION = event('2026-05-18T09:46:00.000Z', 'Impersonation', [
-  { key: 'requestedByName', value: 'Ronny Lundberg' },
+  { key: 'requestedByName', value: 'Maja Andersson' },
   { key: 'requestedByPersonNumber', value: '198501011234' },
   { key: 'accessReason', value: 'I samtal med kunden' },
 ]);

--- a/frontend/src/layouts/pages/mypages-sections/activity/activity.component.tsx
+++ b/frontend/src/layouts/pages/mypages-sections/activity/activity.component.tsx
@@ -97,7 +97,7 @@ export const ActivityComponent = () => {
     return (
       data &&
       data.totalPages > 1 && (
-        <div className="flex justify-center">
+        <div className="flex justify-center" data-cy="activity-pagination">
           <Pagination
             fitContainer={true}
             pages={data.totalPages}


### PR DESCRIPTION
# Pull Request

## Description

Adds Cypress E2E coverage for the **Aktivitet** page (frontend only) — the dedicated testing subtask for the activity view. Feature subtasks shipped test-free by design; this consolidates the coverage in one place.

New files:
- **`cypress/e2e/aktivitet.cy.ts`** — 12 tests: page shell (filter + timeline), each activity type with its badge (Inloggning / Kundtjänst + Supportanledning / HAN-port aktiverad + inaktiverad with Adress + Anläggnings-ID), the empty-personnummer case (no dangling comma), filtering (asserts the `sourceTypeFilter` request query), period selection (`from`/`to`), desktop numbered pagination, empty state, error state (503), and mobile year paging (year → `from=YYYY-01-01`, arrows disabling at the newest/oldest year).
- **`cypress/fixtures/getActivityEvents.ts`** — paged event fixtures (mixed types across two years, a page-two set, and an empty set), typed against the real `PagedEventsResponse`/`EventMetaData` contracts.

Also adds a `data-cy="activity-pagination"` hook on the desktop pagination wrapper so the pagination is selectable in tests.

Follows the existing pattern in `statistik.cy.ts` (shared `setIntercepts`, `cy.intercept` the endpoint, request-query assertions).

## Background & Motivation

Part of the Aktivitet story (**HYDRAN-1821**); this is the final subtask **HYDRAN-2558**, adding automated regression coverage for the page assembled in HYDRAN-2557.

Jira: [HYDRAN-2558](https://jira.sundsvall.se/browse/HYDRAN-2558) (parent story [HYDRAN-1821](https://jira.sundsvall.se/browse/HYDRAN-1821))


## General Checklist

- [x] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [x] Project builds locally without errors
- [x] ESLint/Prettier have been run and are OK
- [x] API changes are documented (OpenAPI/README)
- [x] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [x] All affected pages render correctly (SSR/CSR)
- [x] Navigation works
- [x] API calls from the frontend continue to work
- [x] Any forms/flows function correctly
- [x] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [x] Affected endpoints behave as expected
- [x] No changes break existing contracts
- [x] Error handling works correctly
- [x] Logging behaves normally
- [x] Protected endpoints validated (auth/session/JWT)
