### PR TITLE
Feat/hydran 2715 deny by default auth guard

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -34,7 +34,9 @@ import {
   SESSION_MEMORY,
   SWAGGER_ENABLED,
 } from '@config';
+import authMiddleware from '@middlewares/auth.middleware';
 import errorMiddleware from '@middlewares/error.middleware';
+import { enforceGlobalAuth } from '@middlewares/global-auth';
 import { logger, stream } from '@utils/logger';
 import { defaultMetadataStorage } from 'class-transformer/cjs/storage';
 import { validationMetadatasToSchemas } from 'class-validator-jsonschema';
@@ -193,6 +195,11 @@ class App {
   }
 
   private initializeRoutes(controllers) {
+    // Deny by default: every action without an explicit @Public() gets the auth
+    // middleware injected here, so a forgotten @UseBefore cannot open an endpoint.
+    // Must run before useExpressServer builds the router.
+    enforceGlobalAuth({ authMiddleware, controllers, logger });
+
     useExpressServer(this.app, {
       routePrefix: BASE_URL_PREFIX,
       cors: {

--- a/backend/src/controllers/health.controller.ts
+++ b/backend/src/controllers/health.controller.ts
@@ -3,6 +3,7 @@ import ApiService from '@/services/api.service';
 import { logger } from '@/utils/logger';
 import { Controller, Get } from 'routing-controllers';
 import { OpenAPI } from 'routing-controllers-openapi';
+import { Public } from '@middlewares/global-auth';
 
 @Controller()
 export class HealthController {
@@ -11,6 +12,7 @@ export class HealthController {
 
   @Get('/health/up')
   @OpenAPI({ summary: 'Return health check' })
+  @Public('Liveness probe - polled by infrastructure without a session')
   async up() {
     const url = `${this.apiBase}/simulations/response?status=200%20OK`;
     const data = {

--- a/backend/src/controllers/index.controller.ts
+++ b/backend/src/controllers/index.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get } from 'routing-controllers';
+import { Public } from '@middlewares/global-auth';
 
 @Controller()
 export class IndexController {
   @Get('/')
+  @Public('Service root - returns a constant, no user context')
   index() {
     return 'OK';
   }

--- a/backend/src/middlewares/global-auth.ts
+++ b/backend/src/middlewares/global-auth.ts
@@ -53,6 +53,18 @@ interface UseEntry {
   afterAction: boolean;
 }
 
+/** routing-controllers' metadata store and the two entry shapes read from it. */
+type MetadataStorage = ReturnType<typeof getMetadataArgsStorage>;
+type ActionArgs = MetadataStorage['actions'][number];
+type StoredUse = MetadataStorage['uses'][number];
+
+/** A controller's actions sorted by what the guard needs to do with each. */
+interface ClassifiedActions {
+  publicRoutes: RouteRef[];
+  alreadyProtected: RouteRef[];
+  needsAuth: { action: ActionArgs; ref: RouteRef }[];
+}
+
 export interface RouteRef {
   controller: string;
   action: string;
@@ -177,96 +189,158 @@ export function enforceGlobalAuth(options: EnforceGlobalAuthOptions): AuthGuardR
   const report: AuthGuardReport = { protectedRoutes: [], alreadyProtected: [], publicRoutes: [], warnings: [] };
   const scope = controllers ? new Set<Ctor>(controllers) : null;
 
-  const actionsByController = new Map<Ctor, typeof storage.actions>();
-  for (const action of storage.actions) {
-    const ctor = action.target as Ctor;
-    if (scope && !scope.has(ctor)) continue;
-    const existing = actionsByController.get(ctor);
-    if (existing) {
-      existing.push(action);
-    } else {
-      actionsByController.set(ctor, [action]);
-    }
-  }
-
-  for (const [controller, actions] of actionsByController) {
-    // The @Controller('/prefix') base path, so the report shows the full route.
-    const controllerArgs = storage.controllers.find(entry => entry.target === controller);
-    const basePath = typeof controllerArgs?.route === 'string' ? controllerArgs.route : '';
-
-    // routing-controllers resolves controller-level middleware with an exact
-    // target match and no method, then runs it ahead of all action-level ones.
+  for (const [controller, actions] of groupActionsByController(storage.actions, scope)) {
+    // routing-controllers resolves controller-level middleware with an exact target
+    // match and no method, then runs it ahead of all action-level ones.
     const classLevelUses = storage.uses.filter(use => use.target === controller && !use.method);
     const classIsAuthed = classLevelUses.some(use => use.middleware === authMiddleware);
 
-    const needsAuth: { action: (typeof actions)[number]; ref: RouteRef }[] = [];
-    let publicCount = 0;
+    const classified = classifyActions(storage, controller, actions, authMiddleware, classIsAuthed);
+    report.publicRoutes.push(...classified.publicRoutes);
+    report.alreadyProtected.push(...classified.alreadyProtected);
 
-    for (const action of actions) {
-      const actionName = String(action.method ?? '');
-      const { isPublic, reason } = resolvePublic(controller, actionName);
-      const ref = describeRoute(controller, action, basePath, reason);
-
-      if (isPublic) {
-        publicCount += 1;
-        report.publicRoutes.push(ref);
-        continue;
-      }
-
-      const actionIsAuthed =
-        classIsAuthed ||
-        storage.uses.some(
-          use => use.target === controller && use.method === actionName && use.middleware === authMiddleware,
-        );
-
-      if (actionIsAuthed) {
-        report.alreadyProtected.push(ref);
-        continue;
-      }
-
-      needsAuth.push({ action, ref });
-    }
-
-    if (!needsAuth.length) continue;
+    if (!classified.needsAuth.length) continue;
 
     const foreignClassMiddleware = classLevelUses.filter(use => use.middleware !== authMiddleware);
+    const outcome = protectController({
+      storage,
+      controller,
+      classified,
+      foreignClassMiddleware,
+      authMiddleware,
+      strict,
+    });
 
-    // Class-level middleware runs before anything gets attached per action. When the
-    // whole controller needs auth the application can hoist the guard to class level and stay
-    // ahead of it; otherwise the public routes would inherit auth too.
-    if (foreignClassMiddleware.length && publicCount === 0) {
-      storage.uses.unshift({
-        target: controller,
-        middleware: authMiddleware,
-        afterAction: false,
-      } as UseEntry as unknown as (typeof storage.uses)[number]);
-      needsAuth.forEach(({ ref }) => report.protectedRoutes.push(ref));
-      continue;
-    }
-
-    if (foreignClassMiddleware.length) {
-      const names = foreignClassMiddleware.map(use => use.middleware.name || 'anonymous').join(', ');
-      const message =
-        `${controller.name}: class-level middleware (${names}) runs before the injected auth guard on ` +
-        `${needsAuth.length} route(s), because the controller also has @Public() routes. ` +
-        `Add @UseBefore(authMiddleware) at class level, or move that middleware onto the actions.`;
-      if (strict) throw new Error(`enforceGlobalAuth: ${message}`);
-      report.warnings.push(message);
-    }
-
-    for (const { action, ref } of needsAuth) {
-      storage.uses.unshift({
-        target: controller,
-        method: String(action.method ?? ''),
-        middleware: authMiddleware,
-        afterAction: false,
-      } as UseEntry as unknown as (typeof storage.uses)[number]);
-      report.protectedRoutes.push(ref);
-    }
+    report.protectedRoutes.push(...outcome.protectedRoutes);
+    if (outcome.warning) report.warnings.push(outcome.warning);
   }
 
   logReport(report, logger);
   return report;
+}
+
+/** Groups registered actions by controller, honouring the optional scope. */
+function groupActionsByController(actions: ActionArgs[], scope: Set<Ctor> | null): Map<Ctor, ActionArgs[]> {
+  const grouped = new Map<Ctor, ActionArgs[]>();
+
+  for (const action of actions) {
+    const controller = action.target as Ctor;
+    if (scope && !scope.has(controller)) continue;
+
+    const existing = grouped.get(controller);
+    if (existing) {
+      existing.push(action);
+    } else {
+      grouped.set(controller, [action]);
+    }
+  }
+
+  return grouped;
+}
+
+/** The `@Controller('/prefix')` base path, so reports show the full route. */
+function controllerBasePath(storage: MetadataStorage, controller: Ctor): string {
+  const args = storage.controllers.find(entry => entry.target === controller);
+  return typeof args?.route === 'string' ? args.route : '';
+}
+
+function hasActionLevelAuth(
+  storage: MetadataStorage,
+  controller: Ctor,
+  method: string,
+  authMiddleware: Middleware,
+): boolean {
+  return storage.uses.some(
+    use => use.target === controller && use.method === method && use.middleware === authMiddleware,
+  );
+}
+
+/**
+ * Sorts a controller's actions into the three possible outcomes: deliberately
+ * public, already carrying the auth middleware, and needing it injected.
+ */
+function classifyActions(
+  storage: MetadataStorage,
+  controller: Ctor,
+  actions: ActionArgs[],
+  authMiddleware: Middleware,
+  classIsAuthed: boolean,
+): ClassifiedActions {
+  const basePath = controllerBasePath(storage, controller);
+  const classified: ClassifiedActions = { publicRoutes: [], alreadyProtected: [], needsAuth: [] };
+
+  for (const action of actions) {
+    const actionName = String(action.method ?? '');
+    const { isPublic, reason } = resolvePublic(controller, actionName);
+    const ref = describeRoute(controller, action, basePath, reason);
+
+    if (isPublic) {
+      classified.publicRoutes.push(ref);
+    } else if (classIsAuthed || hasActionLevelAuth(storage, controller, actionName, authMiddleware)) {
+      classified.alreadyProtected.push(ref);
+    } else {
+      classified.needsAuth.push({ action, ref });
+    }
+  }
+
+  return classified;
+}
+
+/** Registers the auth middleware ahead of everything already stored for this target. */
+function injectAuth(storage: MetadataStorage, controller: Ctor, authMiddleware: Middleware, method?: string): void {
+  const entry: UseEntry = { target: controller, middleware: authMiddleware, afterAction: false };
+  if (method !== undefined) entry.method = method;
+  storage.uses.unshift(entry as unknown as StoredUse);
+}
+
+function orderingConflictMessage(controller: Ctor, foreignClassMiddleware: StoredUse[], routeCount: number): string {
+  const names = foreignClassMiddleware.map(use => use.middleware.name || 'anonymous').join(', ');
+  return (
+    `${controller.name}: class-level middleware (${names}) runs before the injected auth guard on ` +
+    `${routeCount} route(s), because the controller also has @Public() routes. ` +
+    `Add @UseBefore(authMiddleware) at class level, or move that middleware onto the actions.`
+  );
+}
+
+/**
+ * Injects the guard for one controller and reports how it went.
+ *
+ * Class-level middleware runs before anything attached per action. When the whole
+ * controller needs auth the guard is hoisted to class level and stays ahead of it.
+ * With `@Public()` routes present that is not possible - they would inherit auth
+ * too - so the guard goes per action and the ordering is flagged instead.
+ */
+function protectController(args: {
+  storage: MetadataStorage;
+  controller: Ctor;
+  classified: ClassifiedActions;
+  foreignClassMiddleware: StoredUse[];
+  authMiddleware: Middleware;
+  strict: boolean;
+}): { protectedRoutes: RouteRef[]; warning?: string } {
+  const { storage, controller, classified, foreignClassMiddleware, authMiddleware, strict } = args;
+  const { needsAuth, publicRoutes } = classified;
+  const protectedRoutes = needsAuth.map(({ ref }) => ref);
+
+  if (foreignClassMiddleware.length && publicRoutes.length === 0) {
+    injectAuth(storage, controller, authMiddleware);
+    return { protectedRoutes };
+  }
+
+  const warning = foreignClassMiddleware.length
+    ? orderingConflictMessage(controller, foreignClassMiddleware, needsAuth.length)
+    : undefined;
+
+  // Thrown before injecting anything, so strict mode leaves this controller untouched.
+  if (warning && strict) {
+    throw new Error(`enforceGlobalAuth: ${warning}`);
+  }
+
+  for (const { action } of needsAuth) {
+    injectAuth(storage, controller, authMiddleware, String(action.method ?? ''));
+  }
+
+  return { protectedRoutes, warning };
 }
 
 function logReport(report: AuthGuardReport, logger?: EnforceGlobalAuthOptions['logger']): void {

--- a/backend/src/middlewares/global-auth.ts
+++ b/backend/src/middlewares/global-auth.ts
@@ -1,0 +1,295 @@
+import { getMetadataArgsStorage } from 'routing-controllers';
+
+/**
+ * Deny-by-default authentication for routing-controllers.
+ *
+ * Auth is normally opt-in: every action needs its own `@UseBefore(authMiddleware)`,
+ * so a forgotten decorator silently publishes an endpoint. This module inverts that.
+ * `enforceGlobalAuth` walks the routing-controllers metadata before the router is
+ * built and injects the auth middleware into every registered action that is not
+ * explicitly marked `@Public()`.
+ *
+ * Usage — call after the controllers have been imported (their decorators must have
+ * run) and before `useExpressServer`:
+ *
+ *   const report = enforceGlobalAuth({ authMiddleware, controllers, logger });
+ *
+ * Opt a route out deliberately:
+ *
+ *   @Get('/health/up')
+ *   @Public('Liveness probe - no user context')
+ *   async up() { ... }
+ *
+ * Portability: this file has no application-specific imports. The auth middleware
+ * is supplied by the caller, so it can be copied verbatim into any backend built on
+ * the same routing-controllers structure.
+ *
+ * Scope and limits:
+ *  - Only covers routes registered through routing-controllers. Routes mounted
+ *    straight onto Express (SAML callbacks, Swagger UI) are untouched and must be
+ *    secured where they are mounted.
+ *  - Controller inheritance is not supported. Actions inherited from a base class
+ *    are matched on their declaring class, which is not how routing-controllers
+ *    resolves them; declare actions on the controller that is registered.
+ *  - Authentication only. It answers "is someone logged in", never "does this
+ *    session own the object being addressed". Per-object authorization is separate.
+ */
+
+/**
+ * A controller class. routing-controllers stores these as plain functions and uses
+ * them purely as identity keys, so this only models what is actually read off them.
+ */
+type Ctor = { readonly name: string; readonly prototype: unknown };
+
+/** An Express-style middleware. Compared by reference and named in reports. */
+type Middleware = { readonly name: string } & ((...args: never[]) => unknown);
+
+/**
+ * Shape of a routing-controllers "use" metadata entry. Declared locally rather
+ * than deep-imported so this module does not depend on the library's internal
+ * file layout.
+ */
+interface UseEntry {
+  target: Ctor;
+  method?: string;
+  middleware: Middleware;
+  afterAction: boolean;
+}
+
+export interface RouteRef {
+  controller: string;
+  action: string;
+  httpMethod: string;
+  route: string;
+  /** Only set for entries in `publicRoutes`, when @Public() was given one. */
+  reason?: string;
+}
+
+export interface AuthGuardReport {
+  /** Routes the guard injected auth into. */
+  protectedRoutes: RouteRef[];
+  /** Routes that already carried the auth middleware via @UseBefore. */
+  alreadyProtected: RouteRef[];
+  /** Routes deliberately opted out with @Public(). */
+  publicRoutes: RouteRef[];
+  /** Ordering problems the guard could not resolve on its own. */
+  warnings: string[];
+}
+
+export interface EnforceGlobalAuthOptions {
+  /**
+   * The middleware that establishes authentication. Matched by reference, so an
+   * existing `@UseBefore(authMiddleware)` is detected and not duplicated.
+   */
+  authMiddleware: Middleware;
+  /**
+   * Controllers being registered. When given, the guard only touches these, which
+   * keeps the report free of controllers that were imported but never mounted.
+   */
+  controllers?: Ctor[];
+  logger?: { info?: (message: string) => void; warn?: (message: string) => void };
+  /**
+   * Throw instead of warning when class-level middleware would run before the
+   * injected guard. Useful in CI. Defaults to false so a boot never fails on what
+   * is an ordering smell rather than a hole.
+   */
+  strict?: boolean;
+}
+
+const publicClasses = new Map<Ctor, string | undefined>();
+const publicMethods = new Map<Ctor, Map<string, string | undefined>>();
+
+/**
+ * Marks a controller or a single action as reachable without authentication.
+ * The optional reason is recorded in the startup report, so the set of open
+ * endpoints stays reviewable.
+ */
+export function Public(reason?: string): ClassDecorator & MethodDecorator {
+  return ((target: any, propertyKey?: string | symbol): void => {
+    if (propertyKey === undefined) {
+      publicClasses.set(target as Ctor, reason);
+      return;
+    }
+    const ctor: Ctor = typeof target === 'function' ? target : target.constructor;
+    let methods = publicMethods.get(ctor);
+    if (!methods) {
+      methods = new Map();
+      publicMethods.set(ctor, methods);
+    }
+    methods.set(String(propertyKey), reason);
+  }) as ClassDecorator & MethodDecorator;
+}
+
+function prototypeChain(target: Ctor): Ctor[] {
+  const chain: Ctor[] = [];
+  for (
+    let current: any = target;
+    typeof current === 'function' && current !== Function.prototype;
+    current = Object.getPrototypeOf(current)
+  ) {
+    chain.push(current);
+  }
+  return chain;
+}
+
+function resolvePublic(target: Ctor, method: string): { isPublic: boolean; reason?: string } {
+  for (const ctor of prototypeChain(target)) {
+    if (publicClasses.has(ctor)) {
+      return { isPublic: true, reason: publicClasses.get(ctor) };
+    }
+    const methods = publicMethods.get(ctor);
+    if (methods?.has(method)) {
+      return { isPublic: true, reason: methods.get(method) };
+    }
+  }
+  return { isPublic: false };
+}
+
+function describeRoute(
+  controller: Ctor,
+  action: { method?: string; type?: string; route?: unknown },
+  basePath: string,
+  reason?: string,
+): RouteRef {
+  const route = typeof action.route === 'string' ? action.route : String(action.route ?? '');
+  return {
+    controller: controller.name,
+    action: String(action.method ?? ''),
+    httpMethod: String(action.type ?? '').toUpperCase(),
+    route: `${basePath}${route}` || '/',
+    ...(reason ? { reason } : {}),
+  };
+}
+
+/**
+ * Injects `authMiddleware` into every registered action that is not `@Public()`.
+ *
+ * Must run after controller decorators have been evaluated (i.e. after the
+ * controllers are imported) and before `useExpressServer` builds the router.
+ * Calling it more than once is safe: already-injected routes are detected by
+ * middleware identity and skipped.
+ */
+export function enforceGlobalAuth(options: EnforceGlobalAuthOptions): AuthGuardReport {
+  const { authMiddleware, controllers, logger, strict = false } = options;
+
+  if (typeof authMiddleware !== 'function') {
+    throw new TypeError('enforceGlobalAuth: authMiddleware must be a function');
+  }
+
+  const storage = getMetadataArgsStorage();
+  const report: AuthGuardReport = { protectedRoutes: [], alreadyProtected: [], publicRoutes: [], warnings: [] };
+  const scope = controllers ? new Set<Ctor>(controllers) : null;
+
+  const actionsByController = new Map<Ctor, typeof storage.actions>();
+  for (const action of storage.actions) {
+    const ctor = action.target as Ctor;
+    if (scope && !scope.has(ctor)) continue;
+    const existing = actionsByController.get(ctor);
+    if (existing) {
+      existing.push(action);
+    } else {
+      actionsByController.set(ctor, [action]);
+    }
+  }
+
+  for (const [controller, actions] of actionsByController) {
+    // The @Controller('/prefix') base path, so the report shows the full route.
+    const controllerArgs = storage.controllers.find(entry => entry.target === controller);
+    const basePath = typeof controllerArgs?.route === 'string' ? controllerArgs.route : '';
+
+    // routing-controllers resolves controller-level middleware with an exact
+    // target match and no method, then runs it ahead of all action-level ones.
+    const classLevelUses = storage.uses.filter(use => use.target === controller && !use.method);
+    const classIsAuthed = classLevelUses.some(use => use.middleware === authMiddleware);
+
+    const needsAuth: { action: (typeof actions)[number]; ref: RouteRef }[] = [];
+    let publicCount = 0;
+
+    for (const action of actions) {
+      const actionName = String(action.method ?? '');
+      const { isPublic, reason } = resolvePublic(controller, actionName);
+      const ref = describeRoute(controller, action, basePath, reason);
+
+      if (isPublic) {
+        publicCount += 1;
+        report.publicRoutes.push(ref);
+        continue;
+      }
+
+      const actionIsAuthed =
+        classIsAuthed ||
+        storage.uses.some(
+          use => use.target === controller && use.method === actionName && use.middleware === authMiddleware,
+        );
+
+      if (actionIsAuthed) {
+        report.alreadyProtected.push(ref);
+        continue;
+      }
+
+      needsAuth.push({ action, ref });
+    }
+
+    if (!needsAuth.length) continue;
+
+    const foreignClassMiddleware = classLevelUses.filter(use => use.middleware !== authMiddleware);
+
+    // Class-level middleware runs before anything we attach per action. When the
+    // whole controller needs auth we can hoist the guard to class level and stay
+    // ahead of it; otherwise the public routes would inherit auth too.
+    if (foreignClassMiddleware.length && publicCount === 0) {
+      storage.uses.unshift({
+        target: controller,
+        middleware: authMiddleware,
+        afterAction: false,
+      } as UseEntry as unknown as (typeof storage.uses)[number]);
+      needsAuth.forEach(({ ref }) => report.protectedRoutes.push(ref));
+      continue;
+    }
+
+    if (foreignClassMiddleware.length) {
+      const names = foreignClassMiddleware.map(use => use.middleware.name || 'anonymous').join(', ');
+      const message =
+        `${controller.name}: class-level middleware (${names}) runs before the injected auth guard on ` +
+        `${needsAuth.length} route(s), because the controller also has @Public() routes. ` +
+        `Add @UseBefore(authMiddleware) at class level, or move that middleware onto the actions.`;
+      if (strict) throw new Error(`enforceGlobalAuth: ${message}`);
+      report.warnings.push(message);
+    }
+
+    for (const { action, ref } of needsAuth) {
+      storage.uses.unshift({
+        target: controller,
+        method: String(action.method ?? ''),
+        middleware: authMiddleware,
+        afterAction: false,
+      } as UseEntry as unknown as (typeof storage.uses)[number]);
+      report.protectedRoutes.push(ref);
+    }
+  }
+
+  logReport(report, logger);
+  return report;
+}
+
+function logReport(report: AuthGuardReport, logger?: EnforceGlobalAuthOptions['logger']): void {
+  if (!logger) return;
+
+  const total = report.protectedRoutes.length + report.alreadyProtected.length + report.publicRoutes.length;
+  logger.info?.(
+    `Auth guard: ${total} routes - ${report.protectedRoutes.length} newly protected, ` +
+      `${report.alreadyProtected.length} already protected, ${report.publicRoutes.length} public`,
+  );
+
+  // The open endpoints are the interesting part of the boot log; name them all.
+  for (const route of report.publicRoutes) {
+    logger.warn?.(
+      `Auth guard: PUBLIC ${route.httpMethod} ${route.route} (${route.controller}.${route.action})` +
+        (route.reason ? ` - ${route.reason}` : ' - no reason given'),
+    );
+  }
+
+  for (const warning of report.warnings) {
+    logger.warn?.(`Auth guard: ${warning}`);
+  }
+}

--- a/backend/src/middlewares/global-auth.ts
+++ b/backend/src/middlewares/global-auth.ts
@@ -9,7 +9,7 @@ import { getMetadataArgsStorage } from 'routing-controllers';
  * built and injects the auth middleware into every registered action that is not
  * explicitly marked `@Public()`.
  *
- * Usage — call after the controllers have been imported (their decorators must have
+ * Usage - call after the controllers have been imported (their decorators must have
  * run) and before `useExpressServer`:
  *
  *   const report = enforceGlobalAuth({ authMiddleware, controllers, logger });
@@ -20,10 +20,7 @@ import { getMetadataArgsStorage } from 'routing-controllers';
  *   @Public('Liveness probe - no user context')
  *   async up() { ... }
  *
- * Portability: this file has no application-specific imports. The auth middleware
- * is supplied by the caller, so it can be copied verbatim into any backend built on
- * the same routing-controllers structure.
- *
+ 
  * Scope and limits:
  *  - Only covers routes registered through routing-controllers. Routes mounted
  *    straight onto Express (SAML callbacks, Swagger UI) are untouched and must be
@@ -234,8 +231,8 @@ export function enforceGlobalAuth(options: EnforceGlobalAuthOptions): AuthGuardR
 
     const foreignClassMiddleware = classLevelUses.filter(use => use.middleware !== authMiddleware);
 
-    // Class-level middleware runs before anything we attach per action. When the
-    // whole controller needs auth we can hoist the guard to class level and stay
+    // Class-level middleware runs before anything gets attached per action. When the
+    // whole controller needs auth the application can hoist the guard to class level and stay
     // ahead of it; otherwise the public routes would inherit auth too.
     if (foreignClassMiddleware.length && publicCount === 0) {
       storage.uses.unshift({
@@ -281,7 +278,7 @@ function logReport(report: AuthGuardReport, logger?: EnforceGlobalAuthOptions['l
       `${report.alreadyProtected.length} already protected, ${report.publicRoutes.length} public`,
   );
 
-  // The open endpoints are the interesting part of the boot log; name them all.
+  // The open endpoints - everyone must be named.
   for (const route of report.publicRoutes) {
     logger.warn?.(
       `Auth guard: PUBLIC ${route.httpMethod} ${route.route} (${route.controller}.${route.action})` +

--- a/backend/src/tests/app-auth.test.ts
+++ b/backend/src/tests/app-auth.test.ts
@@ -1,0 +1,67 @@
+import 'reflect-metadata';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import App from '@/app';
+import { BFUSController } from '@controllers/bfus.controller';
+import { IndexController } from '@controllers/index.controller';
+import { localApi } from '@utils/util';
+
+/**
+ * Proves the guard through the application's own startup sequence.
+ *
+ * `global-auth.test.ts` verifies the injection mechanism, but with a stub auth
+ * middleware that answers 401 itself. The real one never ends the request - it
+ * calls `next(new HttpException(401, ...))` and leaves the response to
+ * `errorMiddleware`, which only reaches the client because `useExpressServer` is
+ * configured with `defaultErrorHandler: false`. Nothing else covers that chain.
+ *
+ * This suite boots the real `App`, so a request passes through the real ordering
+ * of `enforceGlobalAuth` and `useExpressServer`, the real auth middleware, the
+ * real error handler and the configured route prefix.
+ *
+ * The protected route under test deliberately carries no `@UseBefore(authMiddleware)`
+ * of its own - only the guard can be protecting it. Pointing this at a decorated
+ * route instead would make the test pass even if the guard did nothing at all.
+ */
+
+const GUARD_ONLY_ROUTE = localApi('bfus/eligable-party-customer-id');
+const PUBLIC_ROUTE = localApi('/');
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = new App([BFUSController, IndexController]);
+  server = http.createServer(app.getServer());
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>(resolve => server.close(() => resolve()));
+});
+
+async function get(path: string): Promise<{ status: number; body: string }> {
+  const res = await fetch(`${baseUrl}${path}`);
+  return { status: res.status, body: await res.text() };
+}
+
+describe('auth through the real application stack', () => {
+  it('answers 401 on a route that only the guard protects', async () => {
+    const { status } = await get(GUARD_ONLY_ROUTE);
+    expect(status).toBe(401);
+  });
+
+  // The real middleware only calls next(error); this asserts the response that
+  // errorMiddleware produces from it, which is the part the stub never exercises.
+  it('renders the rejection through errorMiddleware', async () => {
+    const { body } = await get(GUARD_ONLY_ROUTE);
+    expect(JSON.parse(body)).toEqual({ message: 'Not Authorized' });
+  });
+
+  it('leaves a @Public() route reachable', async () => {
+    const { status } = await get(PUBLIC_ROUTE);
+    expect(status).toBe(200);
+  });
+});

--- a/backend/src/tests/global-auth.test.ts
+++ b/backend/src/tests/global-auth.test.ts
@@ -1,0 +1,293 @@
+import 'reflect-metadata';
+import express from 'express';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import { Controller, Get, Post, UseBefore, useExpressServer, getMetadataArgsStorage } from 'routing-controllers';
+import { enforceGlobalAuth, Public } from '@middlewares/global-auth';
+
+/**
+ * The guard mutates the process-wide routing-controllers metadata storage, so
+ * each test builds its own controllers and resets the storage afterwards.
+ */
+
+/** Minimal request helper - the repo has no HTTP test client installed. */
+async function call(
+  app: express.Express,
+  method: string,
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<number> {
+  const server = http.createServer(app);
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, { method, headers });
+    return res.status;
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+}
+
+const order: string[] = [];
+
+const authMiddleware = (req: any, res: any, next: any) => {
+  order.push('auth');
+  if (req.headers['x-logged-in'] === 'yes') return next();
+  return res.status(401).json({ message: 'Not Authorized' });
+};
+
+/** Stands in for middleware that assumes auth already ran (mandate, impersonation). */
+const needsUserMiddleware = (req: any, res: any, next: any) => {
+  order.push('needsUser');
+  if (!req.headers['x-logged-in']) return res.status(500).json({ message: 'no user' });
+  return next();
+};
+
+// A class, rather than the bare `Function` the linter rejects. Assignable both to
+// routing-controllers' `Function[]` option and to the guard's controller list.
+type ControllerClass = new () => unknown;
+
+function buildServer(controllers: ControllerClass[]) {
+  const app = express();
+  enforceGlobalAuth({ authMiddleware, controllers });
+  useExpressServer(app, { controllers, defaultErrorHandler: true });
+  return app;
+}
+
+afterEach(() => {
+  getMetadataArgsStorage().reset();
+  order.length = 0;
+});
+
+describe('enforceGlobalAuth', () => {
+  it('protects an action that has no auth decorator', async () => {
+    @Controller()
+    class UndecoratedController {
+      @Post('/grant-permission')
+      grant() {
+        return 'granted';
+      }
+    }
+
+    const app = buildServer([UndecoratedController]);
+
+    expect(await call(app, 'POST', '/grant-permission')).toBe(401);
+    expect(await call(app, 'POST', '/grant-permission', { 'x-logged-in': 'yes' })).toBe(200);
+  });
+
+  it('leaves @Public() actions open', async () => {
+    @Controller()
+    class MixedController {
+      @Get('/health/up')
+      @Public('probe')
+      up() {
+        return 'OK';
+      }
+
+      @Get('/secret')
+      secret() {
+        return 'secret';
+      }
+    }
+
+    const app = buildServer([MixedController]);
+
+    expect(await call(app, 'GET', '/health/up')).toBe(200);
+    expect(await call(app, 'GET', '/secret')).toBe(401);
+  });
+
+  it('treats a class-level @Public() as covering every action', async () => {
+    @Controller()
+    @Public('fully open by design')
+    class OpenController {
+      @Get('/open-a')
+      a() {
+        return 'a';
+      }
+
+      @Get('/open-b')
+      b() {
+        return 'b';
+      }
+    }
+
+    const app = buildServer([OpenController]);
+
+    expect(await call(app, 'GET', '/open-a')).toBe(200);
+    expect(await call(app, 'GET', '/open-b')).toBe(200);
+  });
+
+  it('does not run the auth middleware twice when @UseBefore already applies it', async () => {
+    @Controller()
+    class AlreadyProtectedController {
+      @Get('/already')
+      @UseBefore(authMiddleware)
+      already() {
+        return 'ok';
+      }
+    }
+
+    const app = buildServer([AlreadyProtectedController]);
+
+    expect(await call(app, 'GET', '/already', { 'x-logged-in': 'yes' })).toBe(200);
+    expect(order.filter(entry => entry === 'auth')).toHaveLength(1);
+  });
+
+  it('runs auth before class-level middleware that depends on the user', async () => {
+    @Controller()
+    @UseBefore(needsUserMiddleware)
+    class DependentController {
+      @Get('/dependent')
+      dependent() {
+        return 'ok';
+      }
+    }
+
+    const app = buildServer([DependentController]);
+
+    // Without the guard hoisting auth to class level, needsUserMiddleware would
+    // run first and answer 500 instead of 401.
+    expect(await call(app, 'GET', '/dependent')).toBe(401);
+    expect(order).toEqual(['auth']);
+  });
+
+  it('runs auth before action-level middleware', async () => {
+    @Controller()
+    class ActionMiddlewareController {
+      @Get('/action-mw')
+      @UseBefore(needsUserMiddleware)
+      handler() {
+        return 'ok';
+      }
+    }
+
+    const app = buildServer([ActionMiddlewareController]);
+
+    expect(await call(app, 'GET', '/action-mw')).toBe(401);
+    expect(order).toEqual(['auth']);
+  });
+
+  it('reports what it changed and warns about unreasoned public routes', () => {
+    @Controller()
+    class ReportController {
+      @Get('/injected')
+      injected() {
+        return 'a';
+      }
+
+      @Get('/decorated')
+      @UseBefore(authMiddleware)
+      decorated() {
+        return 'b';
+      }
+
+      @Get('/open')
+      @Public('documented reason')
+      open() {
+        return 'c';
+      }
+    }
+
+    const report = enforceGlobalAuth({ authMiddleware, controllers: [ReportController] });
+
+    expect(report.protectedRoutes.map(r => r.route)).toEqual(['/injected']);
+    expect(report.alreadyProtected.map(r => r.route)).toEqual(['/decorated']);
+    expect(report.publicRoutes).toEqual([
+      expect.objectContaining({ route: '/open', reason: 'documented reason', httpMethod: 'GET' }),
+    ]);
+    expect(report.warnings).toEqual([]);
+  });
+
+  it('warns when a controller mixes @Public() with class-level middleware', () => {
+    @Controller()
+    @UseBefore(needsUserMiddleware)
+    class AmbiguousController {
+      @Get('/ambiguous-open')
+      @Public('open')
+      open() {
+        return 'a';
+      }
+
+      @Get('/ambiguous-closed')
+      closed() {
+        return 'b';
+      }
+    }
+
+    const report = enforceGlobalAuth({ authMiddleware, controllers: [AmbiguousController] });
+
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toContain('AmbiguousController');
+    expect(report.protectedRoutes.map(r => r.route)).toEqual(['/ambiguous-closed']);
+  });
+
+  it('throws on that ambiguity in strict mode', () => {
+    @Controller()
+    @UseBefore(needsUserMiddleware)
+    class StrictController {
+      @Get('/strict-open')
+      @Public('open')
+      open() {
+        return 'a';
+      }
+
+      @Get('/strict-closed')
+      closed() {
+        return 'b';
+      }
+    }
+
+    expect(() => enforceGlobalAuth({ authMiddleware, controllers: [StrictController], strict: true })).toThrow(
+      /StrictController/,
+    );
+  });
+
+  it('is idempotent across repeated calls', async () => {
+    @Controller()
+    class IdempotentController {
+      @Get('/idempotent')
+      handler() {
+        return 'ok';
+      }
+    }
+
+    const app = express();
+    const first = enforceGlobalAuth({ authMiddleware, controllers: [IdempotentController] });
+    const second = enforceGlobalAuth({ authMiddleware, controllers: [IdempotentController] });
+    useExpressServer(app, { controllers: [IdempotentController], defaultErrorHandler: true });
+
+    expect(first.protectedRoutes).toHaveLength(1);
+    expect(second.protectedRoutes).toHaveLength(0);
+    expect(second.alreadyProtected).toHaveLength(1);
+
+    expect(await call(app, 'GET', '/idempotent', { 'x-logged-in': 'yes' })).toBe(200);
+    expect(order.filter(entry => entry === 'auth')).toHaveLength(1);
+  });
+
+  it('ignores controllers outside the given scope', () => {
+    @Controller()
+    class InScopeController {
+      @Get('/in-scope')
+      handler() {
+        return 'a';
+      }
+    }
+
+    @Controller()
+    class OutOfScopeController {
+      @Get('/out-of-scope')
+      handler() {
+        return 'b';
+      }
+    }
+
+    const report = enforceGlobalAuth({ authMiddleware, controllers: [InScopeController] });
+
+    expect(report.protectedRoutes.map(r => r.route)).toEqual(['/in-scope']);
+    expect(getMetadataArgsStorage().uses.some(use => use.target === OutOfScopeController)).toBe(false);
+  });
+
+  it('rejects a non-function auth middleware', () => {
+    expect(() => enforceGlobalAuth({ authMiddleware: undefined as any })).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Auth-skyddet var tidigare per route; varje endpoint behövde `@UseBefore(authMiddleware)` manuellt. En glömd dekorator gav en öppen ändpunkt utan kompileringsfel eller varning. Fem endpoints hade fallit mellan stolarna.

Den här fixen vänder på konceptet: allt ska vara skyddat om det inte uttryckligen märkts `@Public()` (med motivering). Guard'en är byggd utan applikationsspecifika beroenden och kan återanvändas i andra app'ar byggd på samma starter/mono-repo

**Dod:** de fem tidigare öppna endpointsen ska svara 401 om du inte är inloggad. Health och "rot" ska fortfarande funka

## Background & Motivation

https://jira.sundsvall.se/browse/HYDRAN-2715

## General Checklist

- [ ] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [ ] Project builds locally without errors
- [ ] ESLint/Prettier have been run and are OK
- [ ] API changes are documented (OpenAPI/README)
- [ ] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [ ] All affected pages render correctly (SSR/CSR)
- [ ] Navigation works
- [ ] API calls from the frontend continue to work
- [ ] Any forms/flows function correctly
- [ ] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [ ] Affected endpoints behave as expected
- [ ] No changes break existing contracts
- [ ] Error handling works correctly
- [ ] Logging behaves normally
- [ ] Protected endpoints validated (auth/session/JWT)
