### PR TITLE
fix: guards invoice download by what the session has been listed

### DIFF
--- a/backend/src/controllers/invoices.controller.ts
+++ b/backend/src/controllers/invoices.controller.ts
@@ -12,7 +12,7 @@ import { Controller, Get, Param, Req, UseBefore } from 'routing-controllers';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 import { ApiResponse } from '@interfaces/service';
 import InvoicesService, { getInvoicePeriodFrom } from '@/services/invoices.service';
-import { assertOwnsInvoice } from '@/services/ownership.service';
+import { assertInvoiceWasListed, rememberListedInvoices } from '@/services/ownership.service';
 import authMiddleware from '@/middlewares/auth.middleware';
 
 const emptyInvoice = {
@@ -64,6 +64,8 @@ export class InvoicesController {
       limit: Number(limit),
     });
 
+    rememberListedInvoices(req, result.invoices);
+
     return {
       data: {
         invoices: result.invoices,
@@ -103,6 +105,8 @@ export class InvoicesController {
       totalRecords += result.meta?.totalRecords ?? 0;
     }
 
+    rememberListedInvoices(req, allInvoices);
+
     return {
       data: {
         invoices: allInvoices,
@@ -141,6 +145,8 @@ export class InvoicesController {
       limit: 25,
     });
 
+    rememberListedInvoices(req, result.invoices);
+
     const invoice = result.invoices.find(i => i.invoiceNumber === invoiceNumber);
     if (!invoice) throw new HttpException(404, 'Invoice not found');
     return { data: invoice, message: 'success' };
@@ -157,7 +163,10 @@ export class InvoicesController {
       throw new HttpException(400, 'Bad Request');
     }
 
-    await assertOwnsInvoice(req, organizationNumber, id);
+    // The listing endpoints already decided ownership; this reuses that decision.
+    // The search the previous check relied on returns 504 in production for a query
+    // filtered on customer number alone, which is all the download can supply.
+    assertInvoiceWasListed(req, organizationNumber, id);
 
     const url = `${this.apiBase}/${MUNICIPALITY_ID}/COMMERCIAL/${organizationNumber}/${id}/pdf/download`;
     const res = await this.apiService.get<ArrayBuffer>({ url, responseType: 'arraybuffer' }, req.user);

--- a/backend/src/controllers/invoices.controller.ts
+++ b/backend/src/controllers/invoices.controller.ts
@@ -12,7 +12,7 @@ import { Controller, Get, Param, Req, UseBefore } from 'routing-controllers';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 import { ApiResponse } from '@interfaces/service';
 import InvoicesService, { getInvoicePeriodFrom } from '@/services/invoices.service';
-import { assertInvoiceWasListed, rememberListedInvoices } from '@/services/ownership.service';
+import { assertInvoiceAccess, rememberListedInvoices } from '@/services/ownership.service';
 import authMiddleware from '@/middlewares/auth.middleware';
 
 const emptyInvoice = {
@@ -166,7 +166,7 @@ export class InvoicesController {
     // The listing endpoints already decided ownership; this reuses that decision.
     // The search the previous check relied on returns 504 in production for a query
     // filtered on customer number alone, which is all the download can supply.
-    assertInvoiceWasListed(req, organizationNumber, id);
+    await assertInvoiceAccess(req, organizationNumber, id);
 
     const url = `${this.apiBase}/${MUNICIPALITY_ID}/COMMERCIAL/${organizationNumber}/${id}/pdf/download`;
     const res = await this.apiService.get<ArrayBuffer>({ url, responseType: 'arraybuffer' }, req.user);

--- a/backend/src/services/ownership.service.ts
+++ b/backend/src/services/ownership.service.ts
@@ -309,6 +309,7 @@ const INVOICE_SEARCH_CONCURRENCY = 5;
 const fetchInvoicePage = async (
   req: RequestWithUser,
   customerNumbers: string[],
+  facilityIds: string[],
   page: number,
   invoiceNumber: string,
   actingPartyId: string,
@@ -323,6 +324,7 @@ const fetchInvoicePage = async (
           // has no relation with, so filtering on ours would hide those invoices.
           params: {
             customerNumbers: customerNumbers.toString(),
+            ...(facilityIds.length ? { facilityIds } : {}),
             periodFrom: getInvoicePeriodFrom(),
             page,
             limit: SEARCH_PAGE_SIZE,
@@ -373,7 +375,8 @@ export async function assertOwnsInvoice(
     return match;
   };
 
-  const first = await fetchInvoicePage(req, customerNumbers, 1, invoiceNumber, actingPartyId);
+  const facilityIds = Array.from(getAccessibleFacilityIds(req));
+  const first = await fetchInvoicePage(req, customerNumbers, facilityIds, 1, invoiceNumber, actingPartyId);
   const firstMatch = (first?.data?.invoices ?? []).find(invoice => invoice.invoiceNumber === invoiceNumber);
   if (firstMatch) return accept(firstMatch);
 
@@ -382,7 +385,7 @@ export async function assertOwnsInvoice(
   for (let page = 2; page <= lastPage; page += INVOICE_SEARCH_CONCURRENCY) {
     const batch = [];
     for (let offset = 0; offset < INVOICE_SEARCH_CONCURRENCY && page + offset <= lastPage; offset++) {
-      batch.push(fetchInvoicePage(req, customerNumbers, page + offset, invoiceNumber, actingPartyId));
+      batch.push(fetchInvoicePage(req, customerNumbers, facilityIds, page + offset, invoiceNumber, actingPartyId));
     }
 
     for (const res of await Promise.all(batch)) {
@@ -552,11 +555,11 @@ export const rememberListedInvoices = (req: RequestWithUser, invoices: CustomerI
  * invoice API cannot answer in production. The download is always reached from a
  * listed invoice, so the listing is where the decision can be made cheaply.
  */
-export const assertInvoiceWasListed = (
+export const assertInvoiceAccess = async (
   req: RequestWithUser,
   organizationNumber: string,
   invoiceNumber: string,
-): void => {
+): Promise<void> => {
   const actingPartyId = getActingPartyId(req);
 
   if (!invoiceNumber || !organizationNumber) {
@@ -565,13 +568,18 @@ export const assertInvoiceWasListed = (
 
   const listed = req.session?.cache?.listedInvoices ?? {};
 
-  if (!Object.prototype.hasOwnProperty.call(listed, invoiceNumber)) {
-    deny('invoice', invoiceNumber, actingPartyId);
+  if (Object.prototype.hasOwnProperty.call(listed, invoiceNumber)) {
+    // Empty means the listing carried no issuer, so there is nothing to pin it to.
+    const issuer = listed[invoiceNumber];
+    if (issuer && issuer !== organizationNumber) {
+      deny('invoice issuer', organizationNumber, actingPartyId);
+    }
+    return;
   }
 
-  // Empty means the listing carried no issuer, so there is nothing to pin it to.
-  const issuer = listed[invoiceNumber];
-  if (issuer && issuer !== organizationNumber) {
-    deny('invoice issuer', organizationNumber, actingPartyId);
-  }
+  // The record can be incomplete: the invoice page loads both listings at once, and
+  // the session store writes the whole session, so one response can overwrite what
+  // the other just noted. Falling back to the search keeps that from denying a
+  // download the caller is entitled to.
+  await assertOwnsInvoice(req, organizationNumber, invoiceNumber);
 };

--- a/backend/src/services/ownership.service.ts
+++ b/backend/src/services/ownership.service.ts
@@ -303,9 +303,48 @@ export function assertOwnsFacility(req: RequestWithUser, facilityId: string): vo
   }
 }
 
+/** How many invoice pages to request at once while searching. */
+const INVOICE_SEARCH_CONCURRENCY = 5;
+
+const fetchInvoicePage = async (
+  req: RequestWithUser,
+  customerNumbers: string[],
+  page: number,
+  invoiceNumber: string,
+  actingPartyId: string,
+) =>
+  resolveOrDeny(
+    () =>
+      api.get<CustomerInvoicesResponse>(
+        {
+          url: customerInvoicesUrl(),
+          // Customer number is what ties the result to the caller. No issuer
+          // filter: under delegated billing the issuer is a company the customer
+          // has no relation with, so filtering on ours would hide those invoices.
+          params: {
+            customerNumbers: customerNumbers.toString(),
+            periodFrom: getInvoicePeriodFrom(),
+            page,
+            limit: SEARCH_PAGE_SIZE,
+            sortDirection: 'DESC',
+          },
+        },
+        req.user,
+      ),
+    'invoice',
+    invoiceNumber,
+    actingPartyId,
+  );
+
 /**
  * The invoice number cannot be derived from the session, so this searches the
- * caller's own list for it. Costs one platform API call per page.
+ * caller's own list for it.
+ *
+ * The list is paged and can run to thousands of invoices over the search window,
+ * so pages are requested in batches rather than one at a time - walking them in
+ * sequence took long enough to hit the gateway timeout before the PDF was ever
+ * fetched. Each batch is scanned in page order, so the result does not depend on
+ * which request finishes first.
  */
 export async function assertOwnsInvoice(
   req: RequestWithUser,
@@ -325,47 +364,30 @@ export async function assertOwnsInvoice(
     throw new HttpException(403, 'MISSING_CUSTOMER_CONTEXT');
   }
 
-  const url = customerInvoicesUrl();
+  const accept = (match: CustomerInvoice): CustomerInvoice => {
+    // Pin the requested issuer to the one on this invoice, not to our own
+    // relations: under delegated billing another company issues it legitimately.
+    if (match.organizationNumber && match.organizationNumber !== organizationNumber) {
+      deny('invoice issuer', organizationNumber, actingPartyId);
+    }
+    return match;
+  };
 
-  for (let page = 1; page <= MAX_SEARCH_PAGES; page++) {
-    const res = await resolveOrDeny(
-      () =>
-        api.get<CustomerInvoicesResponse>(
-          {
-            url,
-            // Customer number is what ties the result to the caller. No issuer
-            // filter: under delegated billing the issuer is a company the customer
-            // has no relation with, so filtering on ours would hide those invoices.
-            params: {
-              customerNumbers: customerNumbers.toString(),
-              periodFrom: getInvoicePeriodFrom(),
-              page,
-              limit: SEARCH_PAGE_SIZE,
-              sortDirection: 'DESC',
-            },
-          },
-          req.user,
-        ),
-      'invoice',
-      invoiceNumber,
-      actingPartyId,
-    );
+  const first = await fetchInvoicePage(req, customerNumbers, 1, invoiceNumber, actingPartyId);
+  const firstMatch = (first?.data?.invoices ?? []).find(invoice => invoice.invoiceNumber === invoiceNumber);
+  if (firstMatch) return accept(firstMatch);
 
-    const invoices = res?.data?.invoices ?? [];
-    const match = invoices.find(invoice => invoice.invoiceNumber === invoiceNumber);
+  const lastPage = Math.min(first?.data?._meta?.totalPages ?? 1, MAX_SEARCH_PAGES);
 
-    if (match) {
-      // Pin the requested issuer to the one on this invoice, not to our own
-      // relations: under delegated billing another company issues it legitimately.
-      if (match.organizationNumber && match.organizationNumber !== organizationNumber) {
-        deny('invoice issuer', organizationNumber, actingPartyId);
-      }
-      return match;
+  for (let page = 2; page <= lastPage; page += INVOICE_SEARCH_CONCURRENCY) {
+    const batch = [];
+    for (let offset = 0; offset < INVOICE_SEARCH_CONCURRENCY && page + offset <= lastPage; offset++) {
+      batch.push(fetchInvoicePage(req, customerNumbers, page + offset, invoiceNumber, actingPartyId));
     }
 
-    const totalPages = res?.data?._meta?.totalPages ?? page;
-    if (!invoices.length || page >= totalPages) {
-      break;
+    for (const res of await Promise.all(batch)) {
+      const match = (res?.data?.invoices ?? []).find(invoice => invoice.invoiceNumber === invoiceNumber);
+      if (match) return accept(match);
     }
   }
 
@@ -485,5 +507,71 @@ export const assertOwnsBfusContracts = async (req: RequestWithUser, contractIds:
     if (!accessible.has(contractId)) {
       deny('BFUS contract', String(contractId), actingPartyId);
     }
+  }
+};
+
+/**
+ * How many listed invoices to remember. A session lives for days, so the record is
+ * capped and the oldest entries fall out first.
+ */
+const MAX_LISTED_INVOICES = 500;
+
+/**
+ * Notes the invoices handed to this session, keyed by invoice number.
+ *
+ * The listing endpoints already scope their query to the session's own customer
+ * numbers and facilities, so anything they return has been through an ownership
+ * decision. Recording it here lets the download reuse that decision instead of
+ * repeating the search.
+ */
+export const rememberListedInvoices = (req: RequestWithUser, invoices: CustomerInvoice[]): void => {
+  if (!req.session) return;
+
+  req.session.cache = req.session.cache ?? {};
+  const listed = req.session.cache.listedInvoices ?? {};
+
+  for (const invoice of invoices) {
+    if (invoice.invoiceNumber) {
+      listed[invoice.invoiceNumber] = invoice.organizationNumber ?? '';
+    }
+  }
+
+  const numbers = Object.keys(listed);
+  for (const stale of numbers.slice(0, Math.max(0, numbers.length - MAX_LISTED_INVOICES))) {
+    delete listed[stale];
+  }
+
+  req.session.cache.listedInvoices = listed;
+};
+
+/**
+ * Guards the invoice document by what this session has already been shown.
+ *
+ * The ownership search this replaces asked the platform to find the invoice among
+ * the caller's own, which needs a query filtered on customer number alone - one the
+ * invoice API cannot answer in production. The download is always reached from a
+ * listed invoice, so the listing is where the decision can be made cheaply.
+ */
+export const assertInvoiceWasListed = (
+  req: RequestWithUser,
+  organizationNumber: string,
+  invoiceNumber: string,
+): void => {
+  const actingPartyId = getActingPartyId(req);
+
+  if (!invoiceNumber || !organizationNumber) {
+    throw new HttpException(400, 'Bad Request');
+  }
+
+  const listed = req.session?.cache?.listedInvoices ?? {};
+
+  if (!Object.prototype.hasOwnProperty.call(listed, invoiceNumber)) {
+    deny('invoice', invoiceNumber, actingPartyId);
+  }
+
+  // Empty means the listing carried no issuer, so there is nothing to pin it to.
+  const issuer = listed[invoiceNumber];
+  if (issuer && issuer !== organizationNumber) {
+    deny('invoice issuer', organizationNumber, actingPartyId);
   }
 };

--- a/backend/src/tests/ownership.test.ts
+++ b/backend/src/tests/ownership.test.ts
@@ -27,7 +27,7 @@ import {
   assertOwnsFacility,
   assertOwnsFacilityDelegation,
   assertOwnsInvoice,
-  assertInvoiceWasListed,
+  assertInvoiceAccess,
   assertOwnsBfusContracts,
   assertOwnsBfusCustomers,
   getAccessibleBfusCustomerIds,
@@ -496,37 +496,53 @@ describe('invoice download, guarded by what the session was listed', () => {
     return req;
   };
 
-  it('allows an invoice the session has been shown', () => {
+  it('allows an invoice the session has been shown', async () => {
     const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
 
-    expect(() => assertInvoiceWasListed(req, ORG, 'INV-1')).not.toThrow();
+    await expect(assertInvoiceAccess(req, ORG, 'INV-1')).resolves.toBeUndefined();
   });
 
-  it('refuses an invoice the session has never been shown', () => {
+  it('answers from the session without calling the platform API', async () => {
     const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
-
-    expect(() => assertInvoiceWasListed(req, ORG, 'INV-someone-else')).toThrow(
-      expect.objectContaining({ status: 403 }),
-    );
-  });
-
-  it('refuses when the requested issuer is not the one it was listed under', () => {
-    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
-
-    expect(() => assertInvoiceWasListed(req, '9999999999', 'INV-1')).toThrow(expect.objectContaining({ status: 403 }));
-  });
-
-  it('allows an invoice listed without an issuer, since there is nothing to pin', () => {
-    const req = listedSession([{ invoiceNumber: 'INV-1' }]);
-
-    expect(() => assertInvoiceWasListed(req, ORG, 'INV-1')).not.toThrow();
-  });
-
-  it('makes no API call', () => {
-    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
-    assertInvoiceWasListed(req, ORG, 'INV-1');
+    await assertInvoiceAccess(req, ORG, 'INV-1');
 
     expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the requested issuer is not the one it was listed under', async () => {
+    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
+
+    await expectForbidden(assertInvoiceAccess(req, '9999999999', 'INV-1'));
+  });
+
+  it('allows an invoice listed without an issuer, since there is nothing to pin', async () => {
+    const req = listedSession([{ invoiceNumber: 'INV-1' }]);
+
+    await expect(assertInvoiceAccess(req, ORG, 'INV-1')).resolves.toBeUndefined();
+  });
+
+  it('falls back to the search when the session has no record of it', async () => {
+    // The invoice page loads two listings at once and the store writes the whole
+    // session, so one response can overwrite what the other noted.
+    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
+    req.session.cache.relations = { customerNumber: ['cust-1'], customerRelations: [] };
+    upstream([
+      {
+        match: 'customers/invoices',
+        data: { invoices: [{ invoiceNumber: 'INV-clobbered', organizationNumber: ORG }], _meta: { totalPages: 1 } },
+      },
+    ]);
+
+    await expect(assertInvoiceAccess(req, ORG, 'INV-clobbered')).resolves.toBeUndefined();
+    expect(apiGet).toHaveBeenCalled();
+  });
+
+  it('refuses an invoice that is in neither the session nor the search', async () => {
+    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
+    req.session.cache.relations = { customerNumber: ['cust-1'], customerRelations: [] };
+    upstream([{ match: 'customers/invoices', data: { invoices: [], _meta: { totalPages: 1 } } }]);
+
+    await expectForbidden(assertInvoiceAccess(req, ORG, 'INV-someone-else'));
   });
 
   it('caps what it remembers so a long session cannot grow without bound', () => {
@@ -535,10 +551,10 @@ describe('invoice download, guarded by what the session was listed', () => {
       organizationNumber: ORG,
     }));
     const req = listedSession(many);
+    const listed = req.session.cache.listedInvoices;
 
-    expect(Object.keys(req.session.cache.listedInvoices).length).toBe(500);
-    // The most recent survive; the oldest fall out.
-    expect(() => assertInvoiceWasListed(req, ORG, 'INV-599')).not.toThrow();
-    expect(() => assertInvoiceWasListed(req, ORG, 'INV-0')).toThrow();
+    expect(Object.keys(listed).length).toBe(500);
+    expect(listed).toHaveProperty('INV-599');
+    expect(listed).not.toHaveProperty('INV-0');
   });
 });

--- a/backend/src/tests/ownership.test.ts
+++ b/backend/src/tests/ownership.test.ts
@@ -27,11 +27,13 @@ import {
   assertOwnsFacility,
   assertOwnsFacilityDelegation,
   assertOwnsInvoice,
+  assertInvoiceWasListed,
   assertOwnsBfusContracts,
   assertOwnsBfusCustomers,
   getAccessibleBfusCustomerIds,
   assertOwnsParentSetting,
   getActingPartyId,
+  rememberListedInvoices,
 } from '@/services/ownership.service';
 
 const ME = 'party-me';
@@ -385,6 +387,18 @@ describe('assertOwnsInvoice', () => {
     });
     expect(apiGet).toHaveBeenCalledTimes(2);
   });
+
+  it('stops at the page cap instead of walking an unbounded list', async () => {
+    // A production customer can have thousands of invoices over the search window.
+    // Walking every page took long enough to hit the gateway timeout.
+    apiGet.mockImplementation(async () => ({
+      data: { invoices: [{ invoiceNumber: 'INV-other' }], _meta: { totalPages: 100 } },
+      message: 'success',
+    }));
+
+    await expectForbidden(assertOwnsInvoice(sessionWithRelations(), ORG, 'INV-missing'));
+    expect(apiGet.mock.calls.length).toBeLessThanOrEqual(20);
+  });
 });
 
 describe('assertOwnsParentSetting', () => {
@@ -470,5 +484,61 @@ describe('BFUS ownership', () => {
     bfusUpstream({ 'CN-1': 11 }, { 11: [101] });
 
     await expectForbidden(assertOwnsBfusContracts(bfusSession(['CN-1']), [999]));
+  });
+});
+
+describe('invoice download, guarded by what the session was listed', () => {
+  const ORG = '5566778899';
+
+  const listedSession = (invoices: any[]): any => {
+    const req = privateSession();
+    rememberListedInvoices(req, invoices);
+    return req;
+  };
+
+  it('allows an invoice the session has been shown', () => {
+    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
+
+    expect(() => assertInvoiceWasListed(req, ORG, 'INV-1')).not.toThrow();
+  });
+
+  it('refuses an invoice the session has never been shown', () => {
+    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
+
+    expect(() => assertInvoiceWasListed(req, ORG, 'INV-someone-else')).toThrow(
+      expect.objectContaining({ status: 403 }),
+    );
+  });
+
+  it('refuses when the requested issuer is not the one it was listed under', () => {
+    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
+
+    expect(() => assertInvoiceWasListed(req, '9999999999', 'INV-1')).toThrow(expect.objectContaining({ status: 403 }));
+  });
+
+  it('allows an invoice listed without an issuer, since there is nothing to pin', () => {
+    const req = listedSession([{ invoiceNumber: 'INV-1' }]);
+
+    expect(() => assertInvoiceWasListed(req, ORG, 'INV-1')).not.toThrow();
+  });
+
+  it('makes no API call', () => {
+    const req = listedSession([{ invoiceNumber: 'INV-1', organizationNumber: ORG }]);
+    assertInvoiceWasListed(req, ORG, 'INV-1');
+
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('caps what it remembers so a long session cannot grow without bound', () => {
+    const many = Array.from({ length: 600 }, (_, i) => ({
+      invoiceNumber: `INV-${i}`,
+      organizationNumber: ORG,
+    }));
+    const req = listedSession(many);
+
+    expect(Object.keys(req.session.cache.listedInvoices).length).toBe(500);
+    // The most recent survive; the oldest fall out.
+    expect(() => assertInvoiceWasListed(req, ORG, 'INV-599')).not.toThrow();
+    expect(() => assertInvoiceWasListed(req, ORG, 'INV-0')).toThrow();
   });
 });

--- a/backend/src/types/express-session.d.ts
+++ b/backend/src/types/express-session.d.ts
@@ -28,6 +28,8 @@ declare module 'express-session' {
       addresses?: FacilityAddress[];
       facilities?: (InstalledBaseItem & { facilityOwnerPartyId?: string })[];
       delegations?: Delegation[];
+      /** Invoice number -> issuer, for invoices already listed to this session. */
+      listedInvoices?: Record<string, string>;
     };
     signs: {
       details: Record<string, any>;


### PR DESCRIPTION
# Pull Request

## Description

https://jira.sundsvall.se/browse/HYDRAN-2802

## General Checklist

- [ ] PR follows code style and standards
- [ ] E2E tests (Cypress) have been executed, and new tests have been added if required
- [ ] Project builds locally without errors
- [ ] ESLint/Prettier have been run and are OK
- [ ] API changes are documented (OpenAPI/README)
- [ ] Environment variables updated if necessary

## Manual Regression Testing – REQUIRED\*\*

The author of the PR **must** verify that the changes do not break existing functionality.

### Frontend – Next.js

- [ ] All affected pages render correctly (SSR/CSR)
- [ ] Navigation works
- [ ] API calls from the frontend continue to work
- [ ] Any forms/flows function correctly
- [ ] Mobile/desktop tested (if relevant)

### Backend – Express.js

- [ ] Affected endpoints behave as expected
- [ ] No changes break existing contracts
- [ ] Error handling works correctly
- [ ] Logging behaves normally
- [ ] Protected endpoints validated (auth/session/JWT)
